### PR TITLE
AcmModal refactor

### DIFF
--- a/src/AcmButton/AcmButton.tsx
+++ b/src/AcmButton/AcmButton.tsx
@@ -1,7 +1,12 @@
-import { Button } from '@patternfly/react-core'
+import { Button, ButtonVariant } from '@patternfly/react-core'
 import React, { ReactNode } from 'react'
 
-export function AcmButton(props: { children: ReactNode; isDisabled?: boolean; onClick: () => void }) {
+export function AcmButton(props: {
+    children: ReactNode
+    isDisabled?: boolean
+    onClick: () => void
+    variant?: ButtonVariant
+}) {
     return (
         <Button {...props} isDisabled={props.isDisabled}>
             {props.children}

--- a/src/AcmModal/AcmModal.stories.tsx
+++ b/src/AcmModal/AcmModal.stories.tsx
@@ -1,27 +1,53 @@
 import '@patternfly/react-core/dist/styles/base.css'
 import React, { useState } from 'react'
 import { Meta } from '@storybook/react'
+import { ButtonVariant, ModalVariant } from '@patternfly/react-core'
+import { AcmPageCard } from '../AcmPage/AcmPage'
 import { AcmModal } from './AcmModal'
 import { AcmButton } from '../'
 
 const meta: Meta = {
     title: 'Modal',
     component: AcmModal,
+    argTypes: {
+        title: { type: 'string' },
+        message: { type: 'string' },
+        variant: {
+            control: { type: 'select', options: Object.values(ModalVariant) },
+        },
+        titleIconVariant: {
+            control: { type: 'select', options: ['success', 'danger', 'warning', 'info', 'default'] },
+        },
+    },
 }
 export default meta
 
-export const Modal = () => {
+export const Modal = (args) => {
     const [open, toggleOpen] = useState<boolean>(true)
+    const toggle = () => toggleOpen(!open)
     return (
-        <React.Fragment>
-            <AcmButton onClick={() => toggleOpen(true)}>Open Modal</AcmButton>
+        <AcmPageCard>
+            <AcmButton onClick={toggle}>Open Modal</AcmButton>
             <AcmModal
-                open={open}
-                submit={() => toggleOpen((prevOpen) => !prevOpen)}
-                cancel={() => toggleOpen((prevOpen) => !prevOpen)}
-                title="ACM Modal"
-                message="Modal message here"
-            />
-        </React.Fragment>
+                variant={args.variant}
+                titleIconVariant={args.titleIconVariant}
+                isOpen={open}
+                title={args.title}
+                actions={[
+                    <AcmButton key="confirm" variant={ButtonVariant.primary} onClick={toggle}>
+                        Submit
+                    </AcmButton>,
+                    <AcmButton key="cancel" variant={ButtonVariant.link} onClick={toggle}>
+                        Cancel
+                    </AcmButton>,
+                ]}
+            >
+                {args.message}
+            </AcmModal>
+        </AcmPageCard>
     )
+}
+Modal.args = {
+    title: 'ACM Modal',
+    message: 'Modal message here',
 }

--- a/src/AcmModal/AcmModal.test.tsx
+++ b/src/AcmModal/AcmModal.test.tsx
@@ -9,10 +9,10 @@ import { ButtonVariant } from '@patternfly/react-core'
 describe('AcmModal', () => {
     const onSubmit = jest.fn()
     const onCancel = jest.fn()
-    const Component = () => {
+    const Component = (props: { open: boolean }) => {
         return (
             <AcmModal
-                isOpen={true}
+                isOpen={props.open}
                 title="Modal title"
                 actions={[
                     <AcmButton key="confirm" variant={ButtonVariant.primary} onClick={onSubmit}>
@@ -28,7 +28,7 @@ describe('AcmModal', () => {
         )
     }
     test('renders in an open state', () => {
-        const { getByRole, getByText } = render(<Component />)
+        const { getByRole, getByText } = render(<Component open={true} />)
         userEvent.click(getByText('Submit'))
         userEvent.click(getByText('Cancel'))
         expect(getByRole('dialog')).toBeInTheDocument()
@@ -36,11 +36,11 @@ describe('AcmModal', () => {
         expect(onCancel).toHaveBeenCalled()
     })
     test('does not render when in a closed state', () => {
-        const { container } = render(<Component />)
-        expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument()
+        const { queryByText } = render(<Component open={false} />)
+        expect(queryByText('Modal title')).toBeNull()
     })
     test('has zero accessibility defects', async () => {
-        const { container } = render(<Component />)
+        const { container } = render(<Component open={true} />)
         expect(await axe(container)).toHaveNoViolations()
     })
 })

--- a/src/AcmModal/AcmModal.test.tsx
+++ b/src/AcmModal/AcmModal.test.tsx
@@ -3,14 +3,32 @@ import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import { AcmModal } from './AcmModal'
+import { AcmButton } from '../AcmButton/AcmButton'
+import { ButtonVariant } from '@patternfly/react-core'
 
 describe('AcmModal', () => {
-    test('renders in an open state', () => {
-        const onSubmit = jest.fn()
-        const onCancel = jest.fn()
-        const { getByRole, getByText } = render(
-            <AcmModal open={true} submit={onSubmit} cancel={onCancel} title="Modal title" message="Modal message" />
+    const onSubmit = jest.fn()
+    const onCancel = jest.fn()
+    const Component = () => {
+        return (
+            <AcmModal
+                isOpen={true}
+                title="Modal title"
+                actions={[
+                    <AcmButton key="confirm" variant={ButtonVariant.primary} onClick={onSubmit}>
+                        Submit
+                    </AcmButton>,
+                    <AcmButton key="cancel" variant={ButtonVariant.link} onClick={onCancel}>
+                        Cancel
+                    </AcmButton>,
+                ]}
+            >
+                Modal message
+            </AcmModal>
         )
+    }
+    test('renders in an open state', () => {
+        const { getByRole, getByText } = render(<Component />)
         userEvent.click(getByText('Submit'))
         userEvent.click(getByText('Cancel'))
         expect(getByRole('dialog')).toBeInTheDocument()
@@ -18,21 +36,11 @@ describe('AcmModal', () => {
         expect(onCancel).toHaveBeenCalled()
     })
     test('does not render when in a closed state', () => {
-        const { container } = render(
-            <AcmModal
-                open={false}
-                submit={() => null}
-                cancel={() => null}
-                title="Modal title"
-                message="Modal message"
-            />
-        )
+        const { container } = render(<Component />)
         expect(container.querySelector('[role="dialog"]')).not.toBeInTheDocument()
     })
     test('has zero accessibility defects', async () => {
-        const { container } = render(
-            <AcmModal open={true} submit={() => null} cancel={() => null} title="Modal title" message="Modal message" />
-        )
+        const { container } = render(<Component />)
         expect(await axe(container)).toHaveNoViolations()
     })
 })

--- a/src/AcmModal/AcmModal.tsx
+++ b/src/AcmModal/AcmModal.tsx
@@ -1,45 +1,6 @@
 import React from 'react'
-import { Modal, Button, ModalVariant } from '@patternfly/react-core'
+import { Modal, ModalProps } from '@patternfly/react-core'
 
-/* istanbul ignore next */
-export interface IModalProps {
-    open: boolean
-    submit: () => void
-    cancel: () => void
-    title: string
-    message: string
-}
-
-/* istanbul ignore next */
-export const ClosedModalProps: IModalProps = {
-    open: false,
-    submit: () => {
-        /**/
-    },
-    cancel: () => {
-        /**/
-    },
-    title: '',
-    message: '',
-}
-
-export function AcmModal(props: IModalProps) {
-    return (
-        <Modal
-            variant={ModalVariant.medium}
-            title={props.title}
-            isOpen={props.open}
-            onClose={props.cancel}
-            actions={[
-                <Button key="confirm" variant="primary" onClick={props.submit}>
-                    Submit
-                </Button>,
-                <Button key="cancel" variant="link" onClick={props.cancel}>
-                    Cancel
-                </Button>,
-            ]}
-        >
-            {props.message}
-        </Modal>
-    )
+export function AcmModal(props: ModalProps) {
+    return <Modal {...props} ref={null} />
 }


### PR DESCRIPTION
Follow pattern similar to AcmButton where we can re-use the types from Patternfly to pass through props and get full feature function from the PF components.