### PR TITLE
Table sorting off-by-one without bulk actions

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -22,7 +22,7 @@ describe('AcmTable', () => {
     const deleteAction = jest.fn()
     const sortFunction = jest.fn()
     const testItems = exampleData.slice(0, 105)
-    const Table = () => {
+    const Table = ({ bulkActions = false }) => {
         const [items, setItems] = useState<IExampleData[]>(testItems)
         return (
             <AcmTable<IExampleData>
@@ -83,16 +83,20 @@ describe('AcmTable', () => {
                         },
                     },
                 ]}
-                bulkActions={[
-                    {
-                        id: 'delete',
-                        title: 'Delete items',
-                        click: (items: IExampleData[]) => {
-                            setItems(items.filter((i) => !items.find((item) => item.uid === i.uid)))
-                            bulkDeleteAction()
-                        },
-                    },
-                ]}
+                bulkActions={
+                    bulkActions
+                        ? [
+                              {
+                                  id: 'delete',
+                                  title: 'Delete items',
+                                  click: (items: IExampleData[]) => {
+                                      setItems(items.filter((i) => !items.find((item) => item.uid === i.uid)))
+                                      bulkDeleteAction()
+                                  },
+                              },
+                          ]
+                        : []
+                }
                 extraToolbarControls={
                     <ToggleGroup>
                         <ToggleGroupItem isSelected={true} text="View 1" />
@@ -115,7 +119,7 @@ describe('AcmTable', () => {
         expect(createAction).toHaveBeenCalled()
     })
     test('can support bulk table actions with select all', () => {
-        const { getByLabelText, queryByText, getByText } = render(<Table />)
+        const { getByLabelText, queryByText, getByText } = render(<Table bulkActions={true} />)
         expect(getByLabelText('Select all rows')).toBeVisible()
         userEvent.click(getByLabelText('Select all rows'))
         expect(queryByText('Delete items')).toBeVisible()
@@ -123,7 +127,7 @@ describe('AcmTable', () => {
         expect(bulkDeleteAction).toHaveBeenCalled()
     })
     test('can support bulk table actions with single selection', () => {
-        const { queryByText, getAllByRole, getByLabelText } = render(<Table />)
+        const { queryByText, getAllByRole, getByLabelText } = render(<Table bulkActions={true} />)
         expect(queryByText('Delete items')).toBeNull()
         expect(getAllByRole('checkbox')[1]).toBeVisible()
         userEvent.click(getAllByRole('checkbox')[1])
@@ -168,8 +172,9 @@ describe('AcmTable', () => {
         userEvent.type(getByPlaceholderText('Search'), 'A{backspace}')
         expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Abran')
     })
-    test('can be sorted', () => {
-        const { getByText, container } = render(<Table />)
+
+    const sortTest = (bulkActions: boolean) => {
+        const { getByText, container } = render(<Table bulkActions={bulkActions} />)
 
         // sort by string
         expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Abran')
@@ -185,6 +190,13 @@ describe('AcmTable', () => {
         // sort with function
         userEvent.click(getByText('IP Address'))
         expect(sortFunction).toHaveBeenCalled()
+    }
+
+    test('can be sorted', () => {
+        sortTest(false)
+    })
+    test('can be sorted with bulk actions', () => {
+        sortTest(true)
     })
     test('page size can be updated', () => {
         const { getByLabelText, getByText, container } = render(<Table />)

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -81,7 +81,8 @@ export function AcmTable<T>(props: {
     extraToolbarControls?: ReactNode
     emptyState?: ReactNode
 }) {
-    const { items, columns, keyFn } = props
+    const { items, columns, keyFn, bulkActions } = props
+    const sortIndexOffset = bulkActions && bulkActions.length ? 1 : 0
     const [hasSearch, setHasSearch] = useState(true)
     const [searchItems, setSearchItems] = useState<ISearchItem<T>[]>()
     const [filtered, setFiltered] = useState<T[]>(items)
@@ -89,7 +90,10 @@ export function AcmTable<T>(props: {
     const [paged, setPaged] = useState<T[]>()
     const [rows, setRows] = useState<IRow[] | undefined>([])
     const [search, setSearch] = useState('')
-    const [sort, setSort] = useState<ISortBy | undefined>({ index: 1, direction: SortByDirection.asc })
+    const [sort, setSort] = useState<ISortBy | undefined>({
+        index: sortIndexOffset,
+        direction: SortByDirection.asc,
+    })
     const [page, setPage] = useState(1)
     const [perPage, setPerPage] = useState(10)
     const [selected, setSelected] = useState<{ [uid: string]: boolean }>({})
@@ -146,8 +150,8 @@ export function AcmTable<T>(props: {
     }, [search, items, searchItems, columns])
 
     useLayoutEffect(() => {
-        if (sort && sort.index && filtered) {
-            const compare = columns[sort.index - 1].sort
+        if (sort && sort.index != undefined && filtered) {
+            const compare = columns[sort.index - sortIndexOffset].sort
             let sorted: T[] = [...filtered]
             /* istanbul ignore else */
             if (compare) {
@@ -273,13 +277,13 @@ export function AcmTable<T>(props: {
                                 if (value === '') {
                                     /* istanbul ignore next */
                                     if (!sort) {
-                                        setSort({ index: 1, direction: SortByDirection.asc })
+                                        setSort({ index: sortIndexOffset, direction: SortByDirection.asc })
                                     }
                                 }
                             }}
                             onClear={() => {
                                 setSearch('')
-                                setSort({ index: 1, direction: SortByDirection.asc })
+                                setSort({ index: sortIndexOffset, direction: SortByDirection.asc })
                             }}
                             resultsCount={`${filtered.length} / ${items.length}`}
                         />


### PR DESCRIPTION
When there are no bulk actions for a table:
- the 2nd column is sorted by default
- clicking a column header sorts the table by the values in the column to the left of the one clicked