### PR TITLE
TableRow OUIA support

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -222,6 +222,14 @@ describe('AcmTable', () => {
         getByText('Clear all filters').click()
         expect(queryByText('No results found')).toBeNull()
     })
+    test('can provide ouia attributes on table rows', () => {
+        const { container } = render(<Table />)
+        expect(
+            container.querySelector(
+                '[data-ouia-component-type="PF4/TableRow"][data-ouia-component-id="25"] [data-label="First Name"]'
+            )
+        ).toHaveTextContent('Arabela')
+    })
     test('has zero accessibility defects', async () => {
         const { container } = render(<Table />)
         expect(await axe(container)).toHaveNoViolations()

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -16,6 +16,8 @@ import {
 import {
     IRow,
     ISortBy,
+    RowWrapper,
+    RowWrapperProps,
     sortable,
     SortByDirection,
     Table,
@@ -201,12 +203,13 @@ export function AcmTable<T>(props: {
     useLayoutEffect(() => {
         if (paged) {
             const newRows = paged.map((item) => {
+                const key = keyFn(item)
                 return {
-                    selected: selected[keyFn(item)] === true,
-                    props: { key: keyFn(item) },
+                    selected: selected[key] === true,
+                    props: { key },
                     cells: columns.map((column) => {
                         return (
-                            <Fragment key={keyFn(item)}>
+                            <Fragment key={key}>
                                 {typeof column.cell === 'string'
                                     ? get(item as Record<string, unknown>, column.cell)
                                     : column.cell(item)}
@@ -278,6 +281,10 @@ export function AcmTable<T>(props: {
                 </Title>
             </EmptyState>
         )
+    }
+
+    const ouiaIdRowWrapper = (props: RowWrapperProps) => {
+        return <RowWrapper {...props} ouiaId={get(props, 'row.props.key')} />
     }
 
     return (
@@ -370,6 +377,7 @@ export function AcmTable<T>(props: {
                                 }
                             })}
                             rows={rows}
+                            rowWrapper={ouiaIdRowWrapper}
                             actions={actions}
                             canSelectAll={true}
                             aria-label="Simple Table"


### PR DESCRIPTION
This PR introduces a RowWrapper so that the `data-ouia-component-id` can be set to match the row key in our tables. This will enable easier row selection in our Cypress tests.