### PR TITLE
Task/7387/alerts close option

### DIFF
--- a/src/AcmAlert/AcmAlert.stories.tsx
+++ b/src/AcmAlert/AcmAlert.stories.tsx
@@ -14,13 +14,20 @@ export default {
         variant: {
             control: { type: 'select', options: Object.values(AlertVariant) },
         },
+        staticAlert: { type: 'boolean' },
     },
 }
 
 export const Alerts = (args) => {
     return (
         <AcmPageCard>
-            <AcmAlert variant={args.variant} isInline={args.isInline} title={args.title} subtitle={args.subtitle} />
+            <AcmAlert
+                variant={args.variant}
+                isInline={args.isInline}
+                title={args.title}
+                subtitle={args.subtitle}
+                staticAlert={args.staticAlert}
+            />
         </AcmPageCard>
     )
 }

--- a/src/AcmAlert/AcmAlert.stories.tsx
+++ b/src/AcmAlert/AcmAlert.stories.tsx
@@ -14,7 +14,7 @@ export default {
         variant: {
             control: { type: 'select', options: Object.values(AlertVariant) },
         },
-        staticAlert: { type: 'boolean' },
+        noClose: { type: 'boolean' },
     },
 }
 
@@ -26,7 +26,7 @@ export const Alerts = (args) => {
                 isInline={args.isInline}
                 title={args.title}
                 subtitle={args.subtitle}
-                staticAlert={args.staticAlert}
+                noClose={args.noClose}
             />
         </AcmPageCard>
     )

--- a/src/AcmAlert/AcmAlert.test.tsx
+++ b/src/AcmAlert/AcmAlert.test.tsx
@@ -3,6 +3,7 @@ import { render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { AlertVariant } from '@patternfly/react-core'
 import { AcmAlert, AcmAlertGroup } from './AcmAlert'
+import userEvent from '@testing-library/user-event'
 
 describe('AcmAlert', () => {
     test('renders with subtitle of type: string', () => {
@@ -26,6 +27,17 @@ describe('AcmAlert', () => {
     test('renders without subtitle', () => {
         const { queryByText } = render(<AcmAlert title="Acm Alert title" />)
         expect(queryByText('Acm Alert subtitle')).toBeNull()
+    })
+    test('renders with close option', () => {
+        const { getByRole, container } = render(<AcmAlert title="Acm Alert title" />)
+        expect(getByRole('button', { name: 'Close Default alert: alert: Acm Alert title' })).toBeTruthy()
+
+        userEvent.click(getByRole('button', { name: 'Close Default alert: alert: Acm Alert title' }))
+        expect(container.querySelector('[class="pf-c-alert"]')).toBeNull()
+    })
+    test('renders without close option', () => {
+        const { queryByRole } = render(<AcmAlert title="Acm Alert title" staticAlert />)
+        expect(queryByRole('button', { name: 'Close Default alert: alert: Acm Alert title' })).toBeNull()
     })
     test('has zero accessibility defects', async () => {
         const { container } = render(<AcmAlert title="Acm Alert title" />)

--- a/src/AcmAlert/AcmAlert.test.tsx
+++ b/src/AcmAlert/AcmAlert.test.tsx
@@ -36,7 +36,7 @@ describe('AcmAlert', () => {
         expect(container.querySelector('[class="pf-c-alert"]')).toBeNull()
     })
     test('renders without close option', () => {
-        const { queryByRole } = render(<AcmAlert title="Acm Alert title" staticAlert />)
+        const { queryByRole } = render(<AcmAlert title="Acm Alert title" noClose />)
         expect(queryByRole('button', { name: 'Close Default alert: alert: Acm Alert title' })).toBeNull()
     })
     test('has zero accessibility defects', async () => {

--- a/src/AcmAlert/AcmAlert.tsx
+++ b/src/AcmAlert/AcmAlert.tsx
@@ -20,7 +20,7 @@ export function AcmAlert(props: AcmAlertProps) {
 
     const { noClose, ...otherProps } = props
     const [showAlert, setShowAlert] = useState(true)
-    const closeAlert = !noClose && <AlertActionCloseButton onClose={() => setShowAlert(!showAlert)} />
+    const closeAlert = !noClose && <AlertActionCloseButton onClose={() => setShowAlert(false)} />
     return showAlert ? (
         <Alert {...otherProps} actionClose={closeAlert} className={classes.alert}>
             <p>{props.subtitle}</p>

--- a/src/AcmAlert/AcmAlert.tsx
+++ b/src/AcmAlert/AcmAlert.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/styles'
 
 type AcmAlertProps = AlertProps & {
     subtitle?: string | React.ReactNode
-    staticAlert?: boolean
+    noClose?: boolean
 }
 
 const useStyles = makeStyles({
@@ -18,9 +18,9 @@ const useStyles = makeStyles({
 export function AcmAlert(props: AcmAlertProps) {
     const classes = useStyles()
 
-    const { staticAlert, ...otherProps } = props
+    const { noClose, ...otherProps } = props
     const [showAlert, setShowAlert] = useState(true)
-    const closeAlert = !staticAlert && <AlertActionCloseButton onClose={() => setShowAlert(!showAlert)} />
+    const closeAlert = !noClose && <AlertActionCloseButton onClose={() => setShowAlert(!showAlert)} />
     return showAlert ? (
         <Alert {...otherProps} actionClose={closeAlert} className={classes.alert}>
             <p>{props.subtitle}</p>

--- a/src/AcmAlert/AcmAlert.tsx
+++ b/src/AcmAlert/AcmAlert.tsx
@@ -1,17 +1,31 @@
-import React from 'react'
-import { Alert, AlertGroup, AlertProps } from '@patternfly/react-core'
+import React, { useState } from 'react'
+import { Alert, AlertActionCloseButton, AlertGroup, AlertProps } from '@patternfly/react-core'
 import { AlertGroupProps } from '@patternfly/react-core/dist/js/components/AlertGroup/AlertGroup'
+import { makeStyles } from '@material-ui/styles'
 
 type AcmAlertProps = AlertProps & {
     subtitle?: string | React.ReactNode
+    staticAlert?: boolean
 }
 
+const useStyles = makeStyles({
+    alert: {
+        '--pf-c-alert--BoxShadow': '0 1px 2px 0 rgba(0, 0, 0, 0.1)',
+        '--pf-c-alert__icon--MarginRight': '1rem',
+    },
+})
+
 export function AcmAlert(props: AcmAlertProps) {
-    return (
-        <Alert {...props}>
+    const classes = useStyles()
+
+    const { staticAlert, ...otherProps } = props
+    const [showAlert, setShowAlert] = useState(true)
+    const closeAlert = !staticAlert && <AlertActionCloseButton onClose={() => setShowAlert(!showAlert)} />
+    return showAlert ? (
+        <Alert {...otherProps} actionClose={closeAlert} className={classes.alert}>
             <p>{props.subtitle}</p>
         </Alert>
-    )
+    ) : null
 }
 
 export function AcmAlertGroup(props: AlertGroupProps) {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7387

- AcmAlert will be closeable by default. To disable this, add the parameter `noClose`
- Updated styling to the box shadow and spacing between the alert icon and alert text

<img width="778" alt="Screen Shot 2020-12-02 at 10 03 50 AM" src="https://user-images.githubusercontent.com/39634227/100889946-b496ab80-3485-11eb-9518-c46fb9b53809.png">
