### PR TITLE
Custom empty state for tables

### DIFF
--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -399,7 +399,7 @@ export const exampleData: IExampleData[] = [
         firstName: 'Wilt',
         last_name: 'Menhci',
         email: 'wmenhcit@google.co.uk',
-        gender: 'Male',
+        gender: 'Non-binary',
         ip_address: '111.181.112.255',
     },
     {
@@ -855,7 +855,7 @@ export const exampleData: IExampleData[] = [
         firstName: 'Arline',
         last_name: 'Kinworthy',
         email: 'akinworthy2e@about.com',
-        gender: 'Female',
+        gender: 'Non-binary',
         ip_address: '131.198.124.26',
     },
     {

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -160,12 +160,12 @@ describe('AcmTable', () => {
         const { getByPlaceholderText, queryByText, getByLabelText, container } = render(<Table />)
         expect(getByPlaceholderText('Search')).toBeInTheDocument()
         userEvent.type(getByPlaceholderText('Search'), 'Female')
-        expect(queryByText('58 / 105')).toBeVisible()
+        expect(queryByText('57 / 105')).toBeVisible()
 
         // clear table
         expect(getByLabelText('Clear')).toBeVisible()
         userEvent.click(getByLabelText('Clear'))
-        expect(queryByText('58 / 105')).toBeNull()
+        expect(queryByText('57 / 105')).toBeNull()
 
         // verify manually deleting search, resets table with first column sorting
         userEvent.type(getByPlaceholderText('Search'), 'A{backspace}')
@@ -177,8 +177,10 @@ describe('AcmTable', () => {
 
         // sort by string
         expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Abran')
-        userEvent.click(getByText('First Name'))
-        expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Ysabel')
+        userEvent.click(getByText('Gender'))
+        expect(container.querySelector('tbody tr:first-of-type [data-label="Gender"]')).toHaveTextContent('Female')
+        userEvent.click(getByText('Gender'))
+        expect(container.querySelector('tbody tr:first-of-type [data-label="Gender"]')).toHaveTextContent('Non-binary')
 
         // sort by number
         userEvent.click(getByText('UID'))

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -21,7 +21,7 @@ describe('AcmTable', () => {
     const deleteAction = jest.fn()
     const sortFunction = jest.fn()
     const testItems = exampleData.slice(0, 105)
-    const Table = ({ bulkActions = false }) => {
+    const Table = ({ bulkActions = false, ...otherProps }) => {
         const [items, setItems] = useState<IExampleData[]>(testItems)
         return (
             <AcmTable<IExampleData>
@@ -102,6 +102,7 @@ describe('AcmTable', () => {
                         <ToggleGroupItem text="View 2" />
                     </ToggleGroup>
                 }
+                {...otherProps}
             />
         )
     }
@@ -243,6 +244,14 @@ describe('AcmTable', () => {
         userEvent.click(getByText('100 per page'))
         // verify pagination changes on both tables
         expect(container.querySelectorAll('tbody tr')).toHaveLength(200)
+    })
+    test('can provide default empty state', () => {
+        const { queryByText } = render(<Table items={[]} />)
+        expect(queryByText('No addresses found')).toBeVisible()
+    })
+    test('can use custom empty state', () => {
+        const { queryByText } = render(<Table items={[]} emptyState={<div>Look elsewhere!</div>} />)
+        expect(queryByText('Look elsewhere!')).toBeVisible()
     })
     test('has zero accessibility defects', async () => {
         const { container } = render(<Table />)

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -115,7 +115,7 @@ export function AcmTable<T>(props: {
     extraToolbarControls?: ReactNode
     emptyState?: ReactNode
 }) {
-    const { items, columns, keyFn, bulkActions } = props
+    const { emptyState, items, columns, keyFn, bulkActions } = props
     const sortIndexOffset = bulkActions && bulkActions.length ? 1 : 0
     const [hasSearch, setHasSearch] = useState(true)
     const [searchItems, setSearchItems] = useState<ISearchItem<T>[]>()
@@ -381,10 +381,12 @@ export function AcmTable<T>(props: {
                     </Title>
                 </EmptyState>
             ) : items.length === 0 ? (
-                <AcmEmptyState
-                    title={`No ${props.plural} found`}
-                    message={`You do not have any ${props.plural} yet.`}
-                />
+                emptyState || (
+                    <AcmEmptyState
+                        title={`No ${props.plural} found`}
+                        message={`You do not have any ${props.plural} yet.`}
+                    />
+                )
             ) : (
                 <Fragment>
                     <Table


### PR DESCRIPTION
`AcmTable` had an optional `emptyState` prop, but it was not set up to use it. I think we will definitely need the ability to customize the message, so I added that back.

Interestingly, the tests passed with 100% coverage before I added anything for the default empty state or custom empty state. Similarly, there is no test currently for the loading state of the table, so @jamestalton and @showeimer I think our coverage numbers might be a bit inflated. Does it count the statement as long as any part of a ternary executes?