### PR TITLE
add condition for card count visibility

### DIFF
--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
@@ -10,6 +10,12 @@ const meta: Meta = {
 }
 export default meta
 
+const suggestedSearchCardActions = [
+    {
+        text: 'Share',
+        handleAction: () => console.log('share action'),
+    },
+]
 const savedSearchCardActions = [
     { text: 'Edit', handleAction: () => console.log('edit action') },
     { text: 'Share', handleAction: () => console.log('share action') },
@@ -39,7 +45,36 @@ export const ExpandableSavedSearchWrapper = () => {
         )
     })
     return (
-        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'Saved Searches'} withCount={true}>
+        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'Saved searches'} withCount={true} expandable={true}>
+            {renderAcmCountCards}
+        </AcmExpandableWrapper>
+    )
+}
+
+export const nonExpandableSuggestedSearchWrapper = () => {
+    const count = [1, 2, 3]
+    const renderAcmCountCards = count.map((n) => {
+        return (
+            <AcmCountCard
+                key={n}
+                cardHeader={{
+                    hasIcon: true,
+                    title: 'Test Search 2',
+                    description: 'Custom description with max amount of 60 characters',
+                    actions: [...suggestedSearchCardActions],
+                    onActionClick: (e) => {
+                        console.log(e.target)
+                    },
+                }}
+                onCardClick={() => console.log('cardclicked')}
+                count={0}
+                countTitle="Results"
+                isSelectable={true}
+            />
+        )
+    })
+    return (
+        <AcmExpandableWrapper headerLabel={'Suggested search templates'} withCount={false} expandable={false}>
             {renderAcmCountCards}
         </AcmExpandableWrapper>
     )
@@ -59,5 +94,9 @@ export const ExpandableRelatedResWrapper = () => {
             />
         )
     })
-    return <AcmExpandableWrapper maxHeight={'9rem'}>{renderAcmTiles}</AcmExpandableWrapper>
+    return (
+        <AcmExpandableWrapper maxHeight={'9rem'} withCount={false} expandable={true}>
+            {renderAcmTiles}
+        </AcmExpandableWrapper>
+    )
 }

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
@@ -17,7 +17,7 @@ const savedSearchCardActions = [
 ]
 
 export const ExpandableSavedSearchWrapper = () => {
-    const count = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+    const count = [1, 2,3,4,5,6,7]
     const renderAcmCountCards = count.map((n) => {
         return (
             <AcmCountCard
@@ -39,7 +39,7 @@ export const ExpandableSavedSearchWrapper = () => {
         )
     })
     return (
-        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'wrapper label'}>
+        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'Saved Searches'}>
             {renderAcmCountCards}
         </AcmExpandableWrapper>
     )

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
@@ -17,7 +17,7 @@ const savedSearchCardActions = [
 ]
 
 export const ExpandableSavedSearchWrapper = () => {
-    const count = [1, 2,3,4,5,6,7]
+    const count = [1, 2, 3, 4, 5, 6, 7]
     const renderAcmCountCards = count.map((n) => {
         return (
             <AcmCountCard

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.stories.tsx
@@ -39,7 +39,7 @@ export const ExpandableSavedSearchWrapper = () => {
         )
     })
     return (
-        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'Saved Searches'}>
+        <AcmExpandableWrapper maxHeight={'16rem'} headerLabel={'Saved Searches'} withCount={true}>
             {renderAcmCountCards}
         </AcmExpandableWrapper>
     )

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
@@ -7,7 +7,7 @@ import { AcmExpandableWrapper } from '../AcmExpandableWrapper/AcmExpandableWrapp
 
 describe('AcmExpandableWrapper', () => {
     const savedSearchWrapper = () => (
-        <AcmExpandableWrapper headerLabel={'Saved Searches'}>
+        <AcmExpandableWrapper headerLabel={'Saved Searches'} withCount={true}>
             <AcmCountCard
                 cardHeader={{
                     hasIcon: false,
@@ -27,7 +27,7 @@ describe('AcmExpandableWrapper', () => {
     )
 
     const suggestedSearchWrapper = () => (
-        <AcmExpandableWrapper headerLabel={'Suggested Searches'}>
+        <AcmExpandableWrapper headerLabel={'Suggested Searches'} withCount={false}>
             <AcmCountCard
                 cardHeader={{
                     hasIcon: false,

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
@@ -72,5 +72,4 @@ describe('AcmExpandableWrapper', () => {
         const { container } = render(suggestedSearchWrapper())
         expect(container.querySelector('.pf-c-title > span')).not.toBeInTheDocument()
     })
-
 })

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
@@ -7,7 +7,7 @@ import { AcmExpandableWrapper } from '../AcmExpandableWrapper/AcmExpandableWrapp
 
 describe('AcmExpandableWrapper', () => {
     const savedSearchWrapper = () => (
-        <AcmExpandableWrapper headerLabel={'Saved Searches'} withCount={true}>
+        <AcmExpandableWrapper headerLabel={'Saved Searches'} expandable={true} withCount={true}>
             <AcmCountCard
                 cardHeader={{
                     hasIcon: false,
@@ -27,7 +27,7 @@ describe('AcmExpandableWrapper', () => {
     )
 
     const suggestedSearchWrapper = () => (
-        <AcmExpandableWrapper headerLabel={'Suggested Searches'} withCount={false}>
+        <AcmExpandableWrapper headerLabel={'Suggested Searches'} expandable={false} withCount={false}>
             <AcmCountCard
                 cardHeader={{
                     hasIcon: false,
@@ -68,8 +68,9 @@ describe('AcmExpandableWrapper', () => {
         expect(container.querySelector('.pf-c-title > span')).toBeInTheDocument()
     })
 
-    test('suggestedSearchCard does not show count', () => {
+    test('suggestedSearchCard does not show count or show more button', () => {
         const { container } = render(suggestedSearchWrapper())
         expect(container.querySelector('.pf-c-title > span')).not.toBeInTheDocument()
+        expect(container.querySelector('.pf-c-button')).not.toBeInTheDocument()
     })
 })

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.test.tsx
@@ -7,7 +7,27 @@ import { AcmExpandableWrapper } from '../AcmExpandableWrapper/AcmExpandableWrapp
 
 describe('AcmExpandableWrapper', () => {
     const savedSearchWrapper = () => (
-        <AcmExpandableWrapper headerLabel={'wrapper label'}>
+        <AcmExpandableWrapper headerLabel={'Saved Searches'}>
+            <AcmCountCard
+                cardHeader={{
+                    hasIcon: false,
+                    title: 'Test Search 1',
+                    description: 'Custom description with max amount of 60 characters',
+                    actions: [],
+                    onActionClick: (e) => {
+                        console.log(e.target)
+                    },
+                }}
+                onCardClick={() => console.log('cardclicked')}
+                count={1234}
+                countTitle="Results"
+                isSelectable={true}
+            />
+        </AcmExpandableWrapper>
+    )
+
+    const suggestedSearchWrapper = () => (
+        <AcmExpandableWrapper headerLabel={'Suggested Searches'}>
             <AcmCountCard
                 cardHeader={{
                     hasIcon: false,
@@ -33,7 +53,7 @@ describe('AcmExpandableWrapper', () => {
 
     test('validates expandable wrapper renders in collapsed state', () => {
         const { getByText, container } = render(savedSearchWrapper())
-        expect(getByText('wrapper label')).toBeInTheDocument()
+        expect(getByText('Saved Searches')).toBeInTheDocument()
         expect(container.querySelector('.pf-c-button')).toBeInTheDocument()
     })
 
@@ -42,4 +62,15 @@ describe('AcmExpandableWrapper', () => {
         userEvent.click(getByRole('button'))
         expect(getByText('Show less')).toBeInTheDocument()
     })
+
+    test('savedSearchCard shows count', () => {
+        const { container } = render(savedSearchWrapper())
+        expect(container.querySelector('.pf-c-title > span')).toBeInTheDocument()
+    })
+
+    test('suggestedSearchCard does not show count', () => {
+        const { container } = render(suggestedSearchWrapper())
+        expect(container.querySelector('.pf-c-title > span')).not.toBeInTheDocument()
+    })
+
 })

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -33,7 +33,12 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
 
     return (
         <div className={classes.root}>
-            {headerLabel && <Title headingLevel="h4">{headerLabel}</Title>}
+            {headerLabel && 
+                <Title headingLevel="h4">
+                    {headerLabel} 
+                    {headerLabel === 'Saved Searches' && <span style={{fontWeight: 'lighter'}}> {`( ${React.Children.count(children)} total )`}</span>}
+                </Title>
+            }
             <div
                 className={
                     showAll ? `${classes.wrapperContainer}` : `${classes.wrapperContainer} ${classes.hideExtras}`

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -36,12 +36,14 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
 
     return (
         <div className={classes.root}>
-            {headerLabel && 
+            {headerLabel && (
                 <Title headingLevel="h4">
-                    {headerLabel} 
-                    {headerLabel === 'Saved Searches' && <span className={classes.headerCount}> {`( ${React.Children.count(children)} total )`}</span>}
+                    {headerLabel}
+                    {headerLabel === 'Saved Searches' && (
+                        <span className={classes.headerCount}> {`( ${React.Children.count(children)} total )`}</span>
+                    )}
                 </Title>
-            }
+            )}
             <div
                 className={
                     showAll ? `${classes.wrapperContainer}` : `${classes.wrapperContainer} ${classes.hideExtras}`

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -8,6 +8,7 @@ type AcmExpandableWrapperProps = {
     children: React.ReactNode
     maxHeight?: string
     withCount: boolean
+    expandable: boolean
 }
 
 const useStyles = makeStyles({
@@ -31,7 +32,7 @@ const useStyles = makeStyles({
 })
 
 export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
-    const { children, headerLabel, withCount } = props
+    const { children, headerLabel, withCount, expandable } = props
     const classes = useStyles(props)
     const [showAll, setShowAll] = useState<boolean>(false)
 
@@ -60,7 +61,7 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
                     })}
                 </Grid>
             </div>
-            {headerLabel !== 'Suggested Searches' && (
+            {expandable && (
                 <AcmButton className={classes.showAllButton} variant={'secondary'} onClick={() => setShowAll(!showAll)}>
                     {showAll ? 'Show less' : `Show all (${React.Children.count(children)})`}
                 </AcmButton>

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -14,6 +14,9 @@ const useStyles = makeStyles({
         display: 'flex',
         flexDirection: 'column',
     },
+    headerCount: {
+        fontWeight: 'lighter',
+    },
     wrapperContainer: {
         margin: '1rem 0',
     },
@@ -36,7 +39,7 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
             {headerLabel && 
                 <Title headingLevel="h4">
                     {headerLabel} 
-                    {headerLabel === 'Saved Searches' && <span style={{fontWeight: 'lighter'}}> {`( ${React.Children.count(children)} total )`}</span>}
+                    {headerLabel === 'Saved Searches' && <span className={classes.headerCount}> {`( ${React.Children.count(children)} total )`}</span>}
                 </Title>
             }
             <div

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -7,6 +7,7 @@ type AcmExpandableWrapperProps = {
     headerLabel?: string
     children: React.ReactNode
     maxHeight?: string
+    withCount: boolean
 }
 
 const useStyles = makeStyles({
@@ -30,7 +31,7 @@ const useStyles = makeStyles({
 })
 
 export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
-    const { children, headerLabel } = props
+    const { children, headerLabel, withCount } = props
     const classes = useStyles(props)
     const [showAll, setShowAll] = useState<boolean>(false)
 
@@ -39,7 +40,7 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
             {headerLabel && (
                 <Title headingLevel="h4">
                     {headerLabel}
-                    {headerLabel === 'Saved Searches' && (
+                    {withCount && (
                         <span className={classes.headerCount}> {`( ${React.Children.count(children)} total )`}</span>
                     )}
                 </Title>
@@ -59,9 +60,11 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
                     })}
                 </Grid>
             </div>
-            <AcmButton className={classes.showAllButton} variant={'secondary'} onClick={() => setShowAll(!showAll)}>
-                {showAll ? 'Show less' : `Show all (${React.Children.count(children)})`}
-            </AcmButton>
+            {headerLabel !== 'Suggested Searches' && (
+                <AcmButton className={classes.showAllButton} variant={'secondary'} onClick={() => setShowAll(!showAll)}>
+                    {showAll ? 'Show less' : `Show all (${React.Children.count(children)})`}
+                </AcmButton>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
allows option of counter in wrapper header or show more button.

Saved search cards shows count:
<kbd>
![Screen Shot 2020-12-02 at 5 19 00 PM](https://user-images.githubusercontent.com/10394596/100941583-dd3f9500-34c7-11eb-9e48-f42639503a0c.png)
</kbd>

Suggested does not:
<kbd>
![Screen Shot 2020-12-02 at 9 38 44 PM](https://user-images.githubusercontent.com/10394596/100956623-d8d6a480-34e6-11eb-8584-929186045347.png)

</kbd>