### PR TITLE
Add missing AcmChartGroup export

### DIFF
--- a/src/AcmCharts/index.tsx
+++ b/src/AcmCharts/index.tsx
@@ -1,2 +1,3 @@
 /* istanbul ignore file */
 export * from './AcmDonutChart/AcmDonutChart'
+export * from './AcmChartGroup'


### PR DESCRIPTION
I'm getting this error when trying to use AcmChartGroup.  Hoping this fixes it.

```
'"../../../node_modules/@open-cluster-management/ui-components/lib"' has no exported member named 'AcmChartGroup'. Did you mean 'AcmAlertGroup'?  TS2724

    1 | import { useState } from 'react'
  > 2 | import { AcmChartGroup, AcmDonutChart, AcmPage, AcmPageHeader, AcmOverviewProviders, AcmSummaryList, Provider } from '@open-cluster-management/ui-components'
```