### PR TITLE
Use gallery layout for saved searches and cards

### DIFF
--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 import { makeStyles } from '@material-ui/styles'
 import { AcmButton } from '../AcmButton/AcmButton'
-import { Title, Grid, GridItem } from '@patternfly/react-core'
+import { Title, Gallery, GalleryItem } from '@patternfly/react-core'
 
 type AcmExpandableWrapperProps = {
     headerLabel?: string
@@ -51,15 +51,15 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
                     showAll ? `${classes.wrapperContainer}` : `${classes.wrapperContainer} ${classes.hideExtras}`
                 }
             >
-                <Grid hasGutter sm={6} md={4} lg={4} xl={3}>
+                <Gallery hasGutter sm={6} md={4} lg={4} xl={3}>
                     {React.Children.map(props.children, (child, idx) => {
                         return (
-                            <GridItem>
+                            <GalleryItem>
                                 <div key={`item-${idx}`}>{child}</div>
-                            </GridItem>
+                            </GalleryItem>
                         )
                     })}
-                </Grid>
+                </Gallery>
             </div>
             {expandable && (
                 <AcmButton className={classes.showAllButton} variant={'secondary'} onClick={() => setShowAll(!showAll)}>

--- a/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
+++ b/src/AcmExpandableWrapper/AcmExpandableWrapper.tsx
@@ -51,7 +51,7 @@ export const AcmExpandableWrapper = (props: AcmExpandableWrapperProps) => {
                     showAll ? `${classes.wrapperContainer}` : `${classes.wrapperContainer} ${classes.hideExtras}`
                 }
             >
-                <Gallery hasGutter sm={6} md={4} lg={4} xl={3}>
+                <Gallery hasGutter>
                     {React.Children.map(props.children, (child, idx) => {
                         return (
                             <GalleryItem>


### PR DESCRIPTION
Gallery layout works better than Grid for saved searches and related tiles.

### After:
![image](https://user-images.githubusercontent.com/4671325/101853974-90466900-3b2e-11eb-8ec1-c2ffe8138d09.png)

![image](https://user-images.githubusercontent.com/4671325/101854017-a81ded00-3b2e-11eb-97b6-9cac19012415.png)

### Before

![image](https://user-images.githubusercontent.com/4671325/101854119-dbf91280-3b2e-11eb-9011-ab0e950d89c4.png)

![image](https://user-images.githubusercontent.com/4671325/101854089-cb489c80-3b2e-11eb-8fb6-496d3abc0aed.png)

