### PR TITLE
add bottom spacing to each column

### DIFF
--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -8,6 +8,13 @@ import {
     GridItem,
 } from '@patternfly/react-core'
 import { AcmExpandableCard } from '../AcmExpandable'
+import { makeStyles } from '@material-ui/styles'
+
+const useStyles = makeStyles({
+    descriptionList: {
+        'margin-bottom': 'var(--pf-global--gutter--md)',
+    },
+})
 
 export type ListItems = {
     key: string
@@ -20,14 +27,15 @@ export function AcmDescriptionList(props: {
     leftItems: ListItems[]
     rightItems?: ListItems[] | undefined
 }) {
+    const classes = useStyles()
     return (
         <AcmExpandableCard title={props.title}>
             <Grid sm={12} md={6}>
-                <GridItem>
+                <GridItem className={classes.descriptionList}>
                     <List items={props.leftItems} />
                 </GridItem>
                 {props.rightItems && (
-                    <GridItem>
+                    <GridItem className={classes.descriptionList}>
                         <List items={props.rightItems} />
                     </GridItem>
                 )}

--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
     },
     rightCol: {
         'margin-bottom': '16px',
-    }
+    },
 })
 
 export type ListItems = {

--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -11,9 +11,12 @@ import { AcmExpandableCard } from '../AcmExpandable'
 import { makeStyles } from '@material-ui/styles'
 
 const useStyles = makeStyles({
-    descriptionList: {
+    leftCol: {
         'margin-bottom': 'var(--pf-global--gutter--md)',
     },
+    rightCol: {
+        'margin-bottom': '16px',
+    }
 })
 
 export type ListItems = {
@@ -31,11 +34,11 @@ export function AcmDescriptionList(props: {
     return (
         <AcmExpandableCard title={props.title}>
             <Grid sm={12} md={6}>
-                <GridItem className={classes.descriptionList}>
+                <GridItem className={classes.leftCol}>
                     <List items={props.leftItems} />
                 </GridItem>
                 {props.rightItems && (
-                    <GridItem className={classes.descriptionList}>
+                    <GridItem className={classes.rightCol}>
                         <List items={props.rightItems} />
                     </GridItem>
                 )}


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7670

Right now there is no bottom spacing in the 2 columns. When the page is squished, the last item in the left col and the first item in the right col are stuck together like "Created" and "Clusters" below.

<img width="698" alt="Screen Shot 2020-12-14 at 2 47 40 PM" src="https://user-images.githubusercontent.com/39634227/102155388-79af5300-3e49-11eb-80d8-d5e2c7d5bce3.png">

Screenshots of added spacing are shown below. 
The left column has 24px bottom spacing (RowGap value) so that the vertical spacing between the titles is even when the page is squished. 
The right column has 16px bottom spacing so that the white space around the box is the same.

<img width="542" alt="Screen Shot 2020-12-14 at 8 51 15 PM" src="https://user-images.githubusercontent.com/39634227/102161436-525e8300-3e55-11eb-992e-fb213ce2b4b1.png">
<img width="952" alt="Screen Shot 2020-12-14 at 8 48 47 PM" src="https://user-images.githubusercontent.com/39634227/102158128-c0537c00-3e4e-11eb-88b3-37dfe43b6c51.png">

Final result:
<img width="950" alt="Screen Shot 2020-12-14 at 8 48 23 PM" src="https://user-images.githubusercontent.com/39634227/102158132-c34e6c80-3e4e-11eb-9052-e5b557c94831.png">


