### PR TITLE
update AcmDescriptionList styling

### DIFF
--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles({
         ['@media (max-width:768px)']: {
             'margin-bottom': 'var(--pf-global--gutter--md)',
         },
-    }
+    },
 })
 
 export type ListItems = {

--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -14,9 +14,9 @@ const useStyles = makeStyles({
     leftCol: {
         'margin-bottom': '0px',
         ['@media (max-width:768px)']: {
-            'margin-bottom': 'var(--pf-global--gutter--md)'
-        }
-      }
+            'margin-bottom': 'var(--pf-global--gutter--md)',
+        },
+    }
 })
 
 export type ListItems = {

--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -12,11 +12,11 @@ import { makeStyles } from '@material-ui/styles'
 
 const useStyles = makeStyles({
     leftCol: {
-        'margin-bottom': 'var(--pf-global--gutter--md)',
-    },
-    rightCol: {
-        'margin-bottom': '16px',
-    },
+        'margin-bottom': '0px',
+        ['@media (max-width:768px)']: {
+            'margin-bottom': 'var(--pf-global--gutter--md)'
+        }
+      }
 })
 
 export type ListItems = {
@@ -38,7 +38,7 @@ export function AcmDescriptionList(props: {
                     <List items={props.leftItems} />
                 </GridItem>
                 {props.rightItems && (
-                    <GridItem className={classes.rightCol}>
+                    <GridItem>
                         <List items={props.rightItems} />
                     </GridItem>
                 )}

--- a/src/AcmExpandable/AcmExpandableCard/AcmExpandableCard.tsx
+++ b/src/AcmExpandable/AcmExpandableCard/AcmExpandableCard.tsx
@@ -5,7 +5,7 @@ import { makeStyles } from '@material-ui/styles'
 
 const useStyles = makeStyles({
     toggleContainer: { alignSelf: 'center', paddingRight: '12px' },
-    cardBody: { borderTop: '1px solid rgba(0,0,0,0.1)', paddingTop: '40px' },
+    cardBody: { borderTop: '1px solid rgba(0,0,0,0.1)', paddingTop: '32px', paddingBottom: '32px' },
 })
 
 const ToggleIcon = (props: { open: boolean; toggle: () => void }) => {


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/7670

- As discussed with @jackiwakin the AcmDescriptionList will have whitespace of 32px top & bottom and 24px on the sides.
- The previous margin-bottom under on the 2 columns has been removed. Now when the page is squished, only the left column will have the margin-bottom. This way the left column content is spaced evenly above the right column content.

<img width="931" alt="Screen Shot 2020-12-15 at 4 54 45 PM" src="https://user-images.githubusercontent.com/39634227/102277428-4545a080-3ef6-11eb-83ee-09beb0fbc9f0.png">
<img width="872" alt="Screen Shot 2020-12-15 at 4 47 18 PM" src="https://user-images.githubusercontent.com/39634227/102276880-796c9180-3ef5-11eb-9ae9-05db3f7ae614.png">
<img width="731" alt="Screen Shot 2020-12-15 at 4 47 30 PM" src="https://user-images.githubusercontent.com/39634227/102276891-7d98af00-3ef5-11eb-8c03-1b6a2d915d31.png">
