### PR TITLE
Table transforms

### DIFF
--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -1,4 +1,5 @@
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core'
+import { fitContent, truncate } from '@patternfly/react-table'
 import '@patternfly/react-core/dist/styles/base.css'
 import React, { useEffect, useState } from 'react'
 import { AcmPage, AcmPageCard } from '../AcmPage/AcmPage'
@@ -151,6 +152,7 @@ const columns = [
         sort: 'ip_address',
         cell: 'ip_address',
         search: 'ip_address',
+        cellTransforms: [truncate],
     },
     {
         header: 'UID',
@@ -158,6 +160,8 @@ const columns = [
         sort: 'uid',
         cell: 'uid',
         search: 'uid',
+        transforms: [fitContent],
+        cellTransforms: [truncate],
     },
 ]
 

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -1,5 +1,5 @@
 import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core'
-import { SortByDirection } from '@patternfly/react-table'
+import { fitContent, SortByDirection } from '@patternfly/react-table'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
@@ -22,7 +22,7 @@ describe('AcmTable', () => {
     const deleteAction = jest.fn()
     const sortFunction = jest.fn()
     const testItems = exampleData.slice(0, 105)
-    const Table = ({ bulkActions = false, ...otherProps }) => {
+    const Table = ({ bulkActions = false, transforms = false, ...otherProps }) => {
         const [items, setItems] = useState<IExampleData[]>(testItems)
         return (
             <AcmTable<IExampleData>
@@ -63,6 +63,7 @@ describe('AcmTable', () => {
                         cell: 'uid',
                         search: 'uid',
                         tooltip: 'Tooltip Example',
+                        transforms: transforms ? [fitContent] : undefined,
                     },
                 ]}
                 keyFn={(item: IExampleData) => item.uid.toString()}
@@ -109,6 +110,10 @@ describe('AcmTable', () => {
     }
     test('renders', () => {
         const { container } = render(<Table />)
+        expect(container.querySelector('table')).toBeInTheDocument()
+    })
+    test('renders with transforms', () => {
+        const { container } = render(<Table transforms={true} />)
         expect(container.querySelector('table')).toBeInTheDocument()
     })
     test('can support table actions', () => {

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -17,6 +17,7 @@ import {
     IRow,
     ISortBy,
     ITransform,
+    nowrap,
     RowWrapper,
     RowWrapperProps,
     sortable,
@@ -467,7 +468,7 @@ export function AcmTable<T>(props: {
                                           },
                                       }
                                     : {},
-                                transforms: [...(column.transforms || []), ...(column.sort ? [sortable] : [])],
+                                transforms: [nowrap, ...(column.transforms || []), ...(column.sort ? [sortable] : [])],
                                 cellTransforms: column.cellTransforms || [],
                             }
                         })}

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -16,6 +16,7 @@ import {
 import {
     IRow,
     ISortBy,
+    ITransform,
     RowWrapper,
     RowWrapperProps,
     sortable,
@@ -60,6 +61,10 @@ export interface IAcmTableColumn<T> {
 
     /** cell content, either on field name of using cell function */
     cell: CellFn<T> | string
+
+    transforms?: ITransform[]
+
+    cellTransforms?: ITransform[]
 }
 
 /* istanbul ignore next */
@@ -256,12 +261,10 @@ export function AcmTable<T>(props: {
                 selected: selected[key] === true,
                 props: { key },
                 cells: columns.map((column) => {
-                    return (
-                        <Fragment key={key}>
-                            {typeof column.cell === 'string'
-                                ? get(item as Record<string, unknown>, column.cell)
-                                : column.cell(item)}
-                        </Fragment>
+                    return typeof column.cell === 'string' ? (
+                        get(item as Record<string, unknown>, column.cell)
+                    ) : (
+                        <Fragment key={key}>{column.cell(item)}</Fragment>
                     )
                 }),
             }
@@ -367,7 +370,7 @@ export function AcmTable<T>(props: {
         }
     })
 
-    const showActions = items && items.length > 0
+    const showActions = items && items.length
     const showSearch = hasSearch && showActions
     const showToolbar = showSearch || showActions || props.extraToolbarControls
 
@@ -393,7 +396,7 @@ export function AcmTable<T>(props: {
                             </ToolbarItem>
                         )}
                         <ToolbarItem alignment={{ default: 'alignRight' }} />
-                        {items && items.length > 0 ? (
+                        {items && items.length ? (
                             Object.keys(selected).length ? (
                                 <Fragment>
                                     <ToolbarItem>
@@ -464,7 +467,8 @@ export function AcmTable<T>(props: {
                                           },
                                       }
                                     : {},
-                                transforms: column.sort ? [sortable] : undefined,
+                                transforms: [...(column.transforms || []), ...(column.sort ? [sortable] : [])],
+                                cellTransforms: column.cellTransforms || [],
                             }
                         })}
                         rows={rows}
@@ -478,7 +482,7 @@ export function AcmTable<T>(props: {
                         }}
                         onSelect={
                             /* istanbul ignore next */
-                            rows.length > 0 && props.bulkActions && props.bulkActions.length ? onSelect : undefined
+                            rows.length && props.bulkActions?.length ? onSelect : undefined
                         }
                         variant={TableVariant.compact}
                     >
@@ -504,7 +508,7 @@ export function AcmTable<T>(props: {
                             )}
                         </SplitItem>
                     </Split>
-                    {filtered.length === 0 && (
+                    {!filtered.length && (
                         <AcmEmptyState
                             title="No results found"
                             message="No results match the filter criteria. Clear filters to show results."


### PR DESCRIPTION
- make column headers not truncate or wrap by default
- support additional `transforms` and `cellTransforms`