### PR TITLE
Implement dynamic grid breakpoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2345,6 +2345,26 @@
                 "react-lifecycles-compat": "^3.0.4"
             }
         },
+        "@react-hook/latest": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
+            "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg=="
+        },
+        "@react-hook/passive-layout-effect": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
+            "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg=="
+        },
+        "@react-hook/resize-observer": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/@react-hook/resize-observer/-/resize-observer-1.1.0.tgz",
+            "integrity": "sha512-ERM7omDqG/ZzNQz061XHCfYXxGiX68Y46sVi8/ZHjjz7NbZQSxt+dnGkhfEbfsK+JxIzSqSfiXh2pNUl6aYQWA==",
+            "requires": {
+                "@react-hook/latest": "^1.0.2",
+                "@react-hook/passive-layout-effect": "^1.2.0",
+                "resize-observer-polyfill": "^1.5.1"
+            }
+        },
         "@sinonjs/commons": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.1.tgz",
@@ -16123,6 +16143,11 @@
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
             "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
             "dev": true
+        },
+        "resize-observer-polyfill": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
+            "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
         },
         "resolve": {
             "version": "1.19.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "@patternfly/react-charts": "^6.12.2",
         "@patternfly/react-core": "^4.75.2",
         "@patternfly/react-table": "^4.19.5",
+        "@react-hook/resize-observer": "^1.1.0",
         "fuse.js": "^6.4.3",
         "get-value": "^3.0.1",
         "react-router-dom": "^5.2.0",


### PR DESCRIPTION
Prevents table from overflowing its parent box, by dynamically adjusting the `gridBreakPoint` property.

**Before:**
![Before](https://user-images.githubusercontent.com/42188127/102552139-aa33fe80-408e-11eb-9e58-062e7845935e.gif)

**After:**
![After](https://user-images.githubusercontent.com/42188127/102552143-abfdc200-408e-11eb-9715-7ba622f94381.gif)

**After (more narrow example):**
![AfterNarrow](https://user-images.githubusercontent.com/42188127/102552539-64c40100-408f-11eb-8ab3-cc17097acb51.gif)
