### PR TITLE
regression fix

### DIFF
--- a/src/AcmActionGroup/AcmActionGroup.stories.tsx
+++ b/src/AcmActionGroup/AcmActionGroup.stories.tsx
@@ -48,6 +48,7 @@ const ConfigDropdown = () => {
             text="Download configuration"
             dropdownItems={dropdownItems}
             isKebab={false}
+            isPlain={true}
         />
     )
 }
@@ -69,6 +70,7 @@ const ActionDropdown = () => {
             text="Actions"
             dropdownItems={dropdownItems}
             isKebab={false}
+            isPlain={true}
         />
     )
 }

--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -52,7 +52,7 @@ const useStyles = makeStyles({
             '&:hover, &:focus': {
                 '& span': {
                     color: (props: AcmDropdownProps) =>
-                        props.isKebab ? undefined : 'var(--pf-global--Color--light-100)',
+                        props.isKebab ? undefined : 'var(--pf-global--primary-color--100)',
                 },
             },
         },


### PR DESCRIPTION
My last PR introduced a regression when editing button text style. This reverts the change. Also updates AcmDropdown in AcmAlertgroup.stories.tsx to use updated prop "isPlain"

Before (with onHover active) :
<img width="577" alt="Screen Shot 2020-12-22 at 9 31 37 AM" src="https://user-images.githubusercontent.com/21374229/102899154-7f53fc80-4438-11eb-9d4a-3a147d260356.png">

After (with onHover active) :
<img width="630" alt="Screen Shot 2020-12-22 at 9 30 36 AM" src="https://user-images.githubusercontent.com/21374229/102899026-5b90b680-4438-11eb-8de8-4d40193d6ac7.png">