### PR TITLE
Primary button disable color

### DIFF
--- a/src/AcmDropdown/AcmDropdown.test.tsx
+++ b/src/AcmDropdown/AcmDropdown.test.tsx
@@ -80,7 +80,17 @@ describe('AcmDropdown', () => {
         expect(queryByTestId('install-config')).toBeNull()
         await new Promise((resolve) => setTimeout(resolve, 0))
     })
-    test('renders as primary toggle', async () => {
+    test('renders as enabled primary toggle', async () => {
+        const { getByTestId, queryByTestId } = render(
+            <Component isDisabled={false} tooltip="Tooltip text" isPrimary={true} />
+        )
+        expect(getByTestId('dropdown')).toBeInTheDocument()
+        userEvent.click(getByTestId('dropdown'))
+        expect(queryByTestId('install-config')).toBeInTheDocument()
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+
+    test('renders as disabled primary toggle', async () => {
         const { getByTestId, queryByTestId } = render(
             <Component isDisabled={true} tooltip="Tooltip text" isPrimary={true} />
         )

--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -42,9 +42,9 @@ const useStyles = makeStyles({
     button: {
         '& button': {
             backgroundColor: (props: AcmDropdownProps) => {
-                if(props.isDisabled){
+                if (props.isDisabled) {
                     return 'var(--pf-global--disabled-color--200)'
-                } 
+                }
                 return undefined
             },
             '& span': {
@@ -67,9 +67,9 @@ const useStyles = makeStyles({
             },
             '& span.pf-c-dropdown__toggle-text': {
                 // centers dropdown text in plain dropdown button
-                paddingLeft:(props: AcmDropdownProps) =>{
+                paddingLeft: (props: AcmDropdownProps) => {
                     if (props.isPlain) {
-                    return '8px'
+                        return '8px'
                     }
                     return undefined
                 },

--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -39,20 +39,39 @@ export type AcmDropdownItems = {
 }
 
 const useStyles = makeStyles({
-    buttonTitle: {
+    button: {
         '& button': {
+            backgroundColor: (props: AcmDropdownProps) => {
+                if(props.isDisabled){
+                    return 'var(--pf-global--disabled-color--200)'
+                } 
+                return undefined
+            },
             '& span': {
-                color: (props: AcmDropdownProps) =>
-                    props.isPrimary
-                        ? 'var(--pf-global--Color--light-100)'
-                        : props.isKebab
-                        ? undefined
-                        : 'var(--pf-global--primary-color--100)',
+                color: (props: AcmDropdownProps) => {
+                    if (props.isDisabled) {
+                        return 'var(--pf-global--Color--100)'
+                    } else if (props.isPrimary) {
+                        return 'var(--pf-global--Color--light-100)'
+                    } else if (props.isKebab) {
+                        return undefined
+                    }
+                    return 'var(--pf-global--primary-color--100)'
+                },
             },
             '&:hover, &:focus': {
                 '& span': {
                     color: (props: AcmDropdownProps) =>
                         props.isKebab ? undefined : 'var(--pf-global--primary-color--100)',
+                },
+            },
+            '& span.pf-c-dropdown__toggle-text': {
+                // centers dropdown text in plain non-primary button
+                paddingLeft:(props: AcmDropdownProps) =>{
+                    if (!props.isPrimary && props.isPlain) {
+                    return '8px'
+                    }
+                    return undefined
                 },
             },
         },
@@ -71,7 +90,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
     return (
         <TooltipWrapper showTooltip={props.isDisabled && !!props.tooltip} tooltip={props.tooltip}>
             <Dropdown
-                className={classes.buttonTitle}
+                className={classes.button}
                 onMouseOver={props.onHover}
                 position={DropdownPosition.right}
                 dropdownItems={props.dropdownItems.map((item) => (

--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -66,9 +66,9 @@ const useStyles = makeStyles({
                 },
             },
             '& span.pf-c-dropdown__toggle-text': {
-                // centers dropdown text in plain non-primary button
+                // centers dropdown text in plain dropdown button
                 paddingLeft:(props: AcmDropdownProps) =>{
-                    if (!props.isPrimary && props.isPlain) {
+                    if (props.isPlain) {
                     return '8px'
                     }
                     return undefined


### PR DESCRIPTION
Fixes spacing and button color when disabled.
Tied to User story: https://github.com/open-cluster-management/backlog/issues/7650

Before (spacing when isPlain prop is enabled):
![Screen Shot 2021-01-03 at 3 56 20 PM](https://user-images.githubusercontent.com/21374229/103501916-ad184880-4e1d-11eb-9d65-c23098db0fbc.png)

After:
![Screen Shot 2021-01-03 at 4 26 32 PM](https://user-images.githubusercontent.com/21374229/103501943-ba353780-4e1d-11eb-9157-7ccd60cd5203.png)

Before (color when disabled):
![Screen Shot 2021-01-03 at 4 34 33 PM](https://user-images.githubusercontent.com/21374229/103501964-ccaf7100-4e1d-11eb-8b1b-2a5ed8c9fb9b.png)

After:
<img width="706" alt="Screen Shot 2021-01-03 at 11 48 30 PM" src="https://user-images.githubusercontent.com/21374229/103502114-37f94300-4e1e-11eb-8d20-bd45d7814b98.png">

