### PR TITLE
allow users to key through search suggestions using arrow keys

### DIFF
--- a/src/AcmSearchbar/AcmSearchbar.css
+++ b/src/AcmSearchbar/AcmSearchbar.css
@@ -162,6 +162,9 @@
     cursor: pointer;
     background: var(--pf-global--BackgroundColor--200);
 }
+.react-tags__suggestions li.is-active {
+    background: var(--pf-global--BackgroundColor--200);
+}
 .react-tags__suggestions li.is-disabled {
     color: var(--pf-global--palette--black-600);
     cursor: auto;

--- a/src/AcmSearchbar/AcmSearchbar.test.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.test.tsx
@@ -139,4 +139,12 @@ describe('AcmSearchbar', () => {
         userEvent.type(getByRole('combobox'), '4 ')
         expect(queryByText('cpu:=4')).toBeInTheDocument()
     })
+
+    test('Validate a user cannot enter a string when using an operator', () => {
+        const { getByText, getByRole, queryByText } = render(<SearchbarWithOperator />)
+        expect(getByText('cpu:=')).toBeInTheDocument()
+        userEvent.click(getByRole('combobox'))
+        userEvent.type(getByRole('combobox'), 'notANumber ')
+        expect(queryByText('cpu:=')).toBeInTheDocument()
+    })
 })

--- a/src/AcmSearchbar/AcmSearchbar.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.tsx
@@ -65,6 +65,15 @@ export function AcmSearchbar(props: AcmSearchbarProps) {
                     setSearchbarTags(searchbarTags)
                 }}
                 onAddition={(tag: DropdownSuggestionsProps) => {
+                    if (
+                        (!tag.id && tag.name === '') ||
+                        (operators.some((operator: string) => currentQuery.endsWith(operator)) &&
+                            isNaN(parseInt(tag.name, 10)))
+                    ) {
+                        // don't allow blank tags to be added to searchbar
+                        // don't allow non-ints to be added when using an operator
+                        return
+                    }
                     if (tag.kind === 'filter') {
                         const newQueryString = `${currentQuery === '' ? '' : `${currentQuery} `}${tag.name}:`
                         setCurrentQuery(newQueryString)
@@ -112,7 +121,7 @@ export function AcmSearchbar(props: AcmSearchbarProps) {
                 autoresize={true}
                 minQueryLength={0}
                 allowNew={!currentQuery.endsWith(':')}
-                delimiters={[' ', ':', ',']}
+                delimiters={[' ', ':', ',', 'Enter']}
                 maxSuggestionsLength={Number.MAX_SAFE_INTEGER}
             />
             <CloseIcon


### PR DESCRIPTION
- Allow users to navigate through dropdown suggestions with arrow keys
- Don't allow users to enter a string when using an operator (ex: `cpu:=string`)