### PR TITLE
Alert Group: Clear by filter

### DIFF
--- a/src/AcmAlert/AcmAlert.stories.tsx
+++ b/src/AcmAlert/AcmAlert.stories.tsx
@@ -86,11 +86,23 @@ export const AlertGroup = (args) => {
             </AcmButton>
         )
     }
+    const ClearInfoAlerts = () => {
+        const alertContext = useContext(AcmAlertContext)
+        return (
+            <AcmButton
+                onClick={() => {
+                    alertContext.clearAlerts((a) => a.type === 'info')
+                }}
+            >
+                Clear Info Alerts
+            </AcmButton>
+        )
+    }
     return (
         <AcmAlertProvider>
             <AcmPageCard>
                 <AcmAlertGroup isInline={args.isInline} canClose={args.canClose} />
-                <AddAlert /> <AddInfo /> <AddSuccess /> <AddWarning /> <AddError /> <ClearAlerts />
+                <AddAlert /> <AddInfo /> <AddSuccess /> <AddWarning /> <AddError /> <ClearAlerts /> <ClearInfoAlerts />
             </AcmPageCard>
         </AcmAlertProvider>
     )

--- a/src/AcmAlert/AcmAlert.stories.tsx
+++ b/src/AcmAlert/AcmAlert.stories.tsx
@@ -101,7 +101,7 @@ export const AlertGroup = (args) => {
     return (
         <AcmAlertProvider>
             <AcmPageCard>
-                <AcmAlertGroup isInline={args.isInline} canClose={args.canClose} />
+                <AcmAlertGroup isInline={args.isInline} canClose={args.canClose} alertMargin="0 0 24px 0" />
                 <AddAlert /> <AddInfo /> <AddSuccess /> <AddWarning /> <AddError /> <ClearAlerts /> <ClearInfoAlerts />
             </AcmPageCard>
         </AcmAlertProvider>

--- a/src/AcmAlert/AcmAlert.test.tsx
+++ b/src/AcmAlert/AcmAlert.test.tsx
@@ -12,9 +12,19 @@ describe('AcmAlert', () => {
                 <AcmAlertContext.Consumer>
                     {(context) => (
                         <Fragment>
-                            <AcmButton onClick={() => context.addAlert({ title: 'Info' })}>Add Info</AcmButton>
-                            <AcmButton onClick={() => context.addAlert({ title: 'Error' })}>Add Error</AcmButton>
+                            <AcmButton onClick={() => context.addAlert({ title: 'Info', type: 'info' })}>
+                                Add Info
+                            </AcmButton>
+                            <AcmButton onClick={() => context.addAlert({ title: 'Error', type: 'danger' })}>
+                                Add Error
+                            </AcmButton>
+                            <AcmButton onClick={() => context.addAlert({ title: 'Warning', type: 'warning' })}>
+                                Add Warning
+                            </AcmButton>
                             <AcmButton onClick={() => context.clearAlerts()}>Clear Alerts</AcmButton>
+                            <AcmButton onClick={() => context.clearAlerts((a) => a.type === 'warning')}>
+                                Clear Warnings
+                            </AcmButton>
                         </Fragment>
                     )}
                 </AcmAlertContext.Consumer>
@@ -31,9 +41,18 @@ describe('AcmAlert', () => {
         getByText('Add Error').click()
         await waitFor(() => expect(queryAllByText('Error')).toHaveLength(2))
 
+        expect(queryAllByText('Warning')).toHaveLength(0)
+        getByText('Add Warning').click()
+        await waitFor(() => expect(queryAllByText('Warning')).toHaveLength(1))
+
         expect(await axe(container)).toHaveNoViolations()
 
-        getByRole('button', { name: 'Close Default alert: alert: Info' }).click()
+        getByText('Clear Warnings').click()
+        await waitFor(() => expect(queryAllByText('Warning')).toHaveLength(0))
+        await waitFor(() => expect(queryAllByText('Info')).toHaveLength(1))
+        await waitFor(() => expect(queryAllByText('Error')).toHaveLength(2))
+
+        getByRole('button', { name: 'Close Info alert: alert: Info' }).click()
         await waitFor(() => expect(queryAllByText('Info')).toHaveLength(0))
 
         getByText('Clear Alerts').click()

--- a/src/AcmAlert/AcmAlert.tsx
+++ b/src/AcmAlert/AcmAlert.tsx
@@ -141,7 +141,7 @@ export function AcmAlert(props: {
     )
 }
 
-export function AcmAlertGroup(props: { isInline?: boolean; canClose?: boolean }) {
+export function AcmAlertGroup(props: { isInline?: boolean; canClose?: boolean; alertMargin?: string }) {
     const alertContext = useContext(AcmAlertContext)
     return alertContext.alertInfos.length > 0 ? (
         <Fragment>
@@ -153,7 +153,7 @@ export function AcmAlertGroup(props: { isInline?: boolean; canClose?: boolean })
                         isInline={props.isInline}
                         noClose={!props.canClose}
                         style={{
-                            marginBottom: '24px',
+                            margin: props.alertMargin,
                         }}
                     />
                 )

--- a/src/AcmAlert/AcmAlert.tsx
+++ b/src/AcmAlert/AcmAlert.tsx
@@ -1,6 +1,15 @@
 import Collapse from '@material-ui/core/Collapse'
 import { Alert, AlertActionCloseButton } from '@patternfly/react-core'
-import React, { createContext, HTMLAttributes, ReactNode, useCallback, useContext, useEffect, useState } from 'react'
+import React, {
+    createContext,
+    CSSProperties,
+    Fragment,
+    ReactNode,
+    useCallback,
+    useContext,
+    useEffect,
+    useState,
+} from 'react'
 
 export interface AcmAlertInfo {
     type?: 'success' | 'danger' | 'warning' | 'info' | 'default'
@@ -61,7 +70,7 @@ export function AcmAlert(props: {
     message?: ReactNode
     noClose?: boolean
     variant?: 'success' | 'danger' | 'warning' | 'info' | 'default'
-    style?: HTMLAttributes<HTMLDivElement>
+    style?: CSSProperties
 }) {
     const alertContext = useContext(AcmAlertContext)
     const { alertInfo } = props
@@ -73,7 +82,6 @@ export function AcmAlert(props: {
     }, [alertContext])
     return (
         <Collapse
-            style={props.style}
             in={open}
             onExit={() => {
                 /* istanbul ignore else */
@@ -83,16 +91,15 @@ export function AcmAlert(props: {
             }}
             timeout={200}
         >
-            <div style={{ paddingBottom: '8px' }}>
-                <Alert
-                    isInline={props.isInline}
-                    title={alertInfo?.title || props.title}
-                    actionClose={!props.noClose && <AlertActionCloseButton onClose={() => setOpen(false)} />}
-                    variant={alertInfo?.type || props.variant}
-                >
-                    {alertInfo?.message || props.message || props.subtitle}
-                </Alert>
-            </div>
+            <Alert
+                isInline={props.isInline}
+                title={alertInfo?.title || props.title}
+                actionClose={!props.noClose && <AlertActionCloseButton onClose={() => setOpen(false)} />}
+                variant={alertInfo?.type || props.variant}
+                style={props.style}
+            >
+                {alertInfo?.message || props.message || props.subtitle}
+            </Alert>
         </Collapse>
     )
 }
@@ -100,16 +107,21 @@ export function AcmAlert(props: {
 export function AcmAlertGroup(props: { isInline?: boolean; canClose?: boolean }) {
     const alertContext = useContext(AcmAlertContext)
     return alertContext.alertInfos.length > 0 ? (
-        <div style={{ paddingBottom: '16px' }}>
-            {alertContext.alertInfos.map((alertInfo) => (
-                <AcmAlert
-                    key={alertInfo.id}
-                    alertInfo={alertInfo}
-                    isInline={props.isInline}
-                    noClose={!props.canClose}
-                />
-            ))}
-        </div>
+        <Fragment>
+            {alertContext.alertInfos.map((alertInfo) => {
+                return (
+                    <AcmAlert
+                        key={alertInfo.id}
+                        alertInfo={alertInfo}
+                        isInline={props.isInline}
+                        noClose={!props.canClose}
+                        style={{
+                            marginBottom: '24px',
+                        }}
+                    />
+                )
+            })}
+        </Fragment>
     ) : (
         <></>
     )


### PR DESCRIPTION
Allows clearing alerts based on a filter.
Example would be if you had alerts coming from two different operations.
Retrying one, you might want to clear the old alert on the retry, but only for what was retried.