### PR TITLE
Allow user to enter filters that dont match a suggestion option

### DIFF
--- a/src/AcmSearchbar/AcmSearchbar.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.tsx
@@ -120,7 +120,7 @@ export function AcmSearchbar(props: AcmSearchbarProps) {
                 noSuggestionsText={'No matching filters'}
                 autoresize={true}
                 minQueryLength={0}
-                allowNew={!currentQuery.endsWith(':')}
+                allowNew={true}
                 delimiters={[' ', ':', ',', 'Enter']}
                 maxSuggestionsLength={Number.MAX_SAFE_INTEGER}
             />


### PR DESCRIPTION
https://github.com/open-cluster-management/backlog/issues/8399

Fixes: `Can't submit a search when there's no matching filters. For example, can't search for: kind:abc`