### PR TITLE
Fix refetch button

### DIFF
--- a/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
+++ b/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
@@ -142,7 +142,7 @@ export function AcmAutoRefreshSelect(props: AcmAutoRefreshSelectProps) {
                 id={'refresh-icon'}
                 aria-label={'refresh-icon'}
                 role={'button'}
-                onClick={refetch}
+                onClick={() => refetch()}
                 onKeyPress={handleKeyPress}
             >
                 <SyncAltIcon className={classes.icon} />


### PR DESCRIPTION
### Description:

onClick will pass an event as an argument, this is causing a problem because refetch() is getting the event and trying to use it in the graphql query. 