### PR TITLE
fix for Primary button onHover

### DIFF
--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -71,6 +71,12 @@ const useStyles = makeStyles({
                     color: (props: AcmDropdownProps) =>
                         props.isKebab ? undefined : 'var(--pf-global--primary-color--100)',
                 },
+                '& span.pf-c-dropdown__toggle-text': {
+                    color: (props: AcmDropdownProps) => props.isPrimary && 'var(--pf-global--Color--light-100)',
+                },
+                '& span.pf-c-dropdown__toggle-icon': {
+                    color: (props: AcmDropdownProps) => props.isPrimary && 'var(--pf-global--Color--light-100)',
+                },
             },
             '& span.pf-c-dropdown__toggle-text': {
                 // centers dropdown text in plain dropdown button


### PR DESCRIPTION
regarding: https://github.com/open-cluster-management/backlog/issues/8474

Added logic to fill text and logo onHover.

![Screen Shot 2021-01-15 at 4 51 39 PM](https://user-images.githubusercontent.com/21374229/104782579-7104b200-5752-11eb-8a8a-246ccb3bcdd3.png)
