### PR TITLE
Add links to donut chart legend

### DIFF
--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.stories.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.stories.tsx
@@ -9,11 +9,26 @@ export default {
 
 export const DonutChart = () => {
     const complianceData = [
-        { key: 'Compliant', value: 1, isPrimary: true },
-        { key: 'Non-compliant', value: 1, isDanger: true },
+        {
+            key: 'Compliant',
+            value: 1,
+            isPrimary: true,
+            link: '/search?filters={"textsearch":"kind%3Apolicy%20compliant%3Acompliant"}',
+        },
+        {
+            key: 'Non-compliant',
+            value: 1,
+            isDanger: true,
+            link: '/search?filters={"textsearch":"kind%3Apolicy%20compliant%3Anoncompliant"}',
+        },
     ]
     const podData = [
-        { key: 'Running', value: 90, isPrimary: true },
+        {
+            key: 'Running',
+            value: 90,
+            isPrimary: true,
+            link: '/search?filters={"textsearch":"kind%3Apod%20status%3ARunning"}',
+        },
         { key: 'Pending', value: 8 },
         { key: 'Failed', value: 2, isDanger: true },
     ]

--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.test.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.test.tsx
@@ -4,7 +4,7 @@ import { axe } from 'jest-axe'
 import { AcmDonutChart } from './AcmDonutChart'
 
 const complianceData = [
-    { key: 'Compliant', value: 1, isPrimary: true },
+    { key: 'Compliant', value: 1, isPrimary: true, link: '/linkToCompiantResources' },
     { key: 'Non-compliant', value: 1, isDanger: true },
 ]
 const zeroData = [
@@ -19,7 +19,7 @@ const podData = [
 
 describe('AcmDonutChart', () => {
     test('renders', () => {
-        const { getByTestId } = render(
+        const { getByRole, getByTestId } = render(
             <AcmDonutChart
                 title="Cluster compliance"
                 description="Overview of policy compliance status"
@@ -27,6 +27,7 @@ describe('AcmDonutChart', () => {
             />
         )
         expect(getByTestId('cluster-compliance-chart')).toBeInTheDocument()
+        expect(getByRole('link')).toBeInTheDocument()
     })
 
     test('renders skeleton', () => {
@@ -37,12 +38,13 @@ describe('AcmDonutChart', () => {
     })
 
     test('renders with zero values state', () => {
-        const { getByText } = render(
+        const { queryByRole, getByText } = render(
             <AcmDonutChart title="Some title" description="Some description" data={zeroData} />
         )
         expect(getByText('0%')).toBeInTheDocument()
         expect(getByText('0 Key1')).toBeInTheDocument()
         expect(getByText('0 Key2')).toBeInTheDocument()
+        expect(queryByRole('link')).toBeNull() // zeroData doesn't declare links.
     })
 
     test('has zero accessibility defects', async () => {

--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
@@ -58,15 +58,16 @@ export const loadingDonutChart = (title: string) => {
     )
 }
 
-const LegendLabel = ({ datum, ...rest }: { datum: Data }) => {
-    if (datum?.link) {
-        return (
-            <a href={datum.link}>
-                <ChartLabel {...rest} />
-            </a>
-        )
-    }
-    return <ChartLabel {...rest} />
+const LegendLabel = ({ ...props }: { datum?: Data }) => {
+    /*istanbul ignore next */
+    const link = props.datum?.link
+    return link ? (
+        <a href={link}>
+            <ChartLabel {...props} />
+        </a>
+    ) : (
+        <ChartLabel {...props} />
+    )
 }
 
 function buildLegendWithLinks(legendData: Array<LegendData>) {

--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
@@ -1,12 +1,23 @@
 import React from 'react'
 import { Card, CardTitle, Badge, Skeleton } from '@patternfly/react-core'
-import { ChartDonut } from '@patternfly/react-charts'
+import { ChartDonut, ChartLabel, ChartLegend } from '@patternfly/react-charts'
 import { makeStyles } from '@material-ui/styles'
 import { useViewport } from '../AcmChartGroup'
 
 type StyleProps = {
     danger?: boolean
     viewWidth: number
+}
+type Data = {
+    key: string
+    value: number
+    isPrimary?: boolean
+    isDanger?: boolean
+    link?: string
+}
+type LegendData = {
+    name?: string
+    link?: string
 }
 
 /* istanbul ignore next */
@@ -47,14 +58,24 @@ export const loadingDonutChart = (title: string) => {
     )
 }
 
-export function AcmDonutChart(props: {
-    title: string
-    description: string
-    data: { key: string; value: number; isPrimary?: boolean; isDanger?: boolean }[]
-    loading?: boolean
-}) {
+const LegendLabel = ({ datum, ...rest }: { datum: Data }) => {
+    if (datum?.link) {
+        return (
+            <a href={datum.link}>
+                <ChartLabel {...rest} />
+            </a>
+        )
+    }
+    return <ChartLabel {...rest} />
+}
+
+function buildLegendWithLinks(legendData: Array<LegendData>) {
+    return <ChartLegend data={legendData} labelComponent={<LegendLabel />} />
+}
+
+export function AcmDonutChart(props: { title: string; description: string; data: Array<Data>; loading?: boolean }) {
     const chartData = props.data.map((d) => ({ x: d.key, y: d.value }))
-    const legendData = props.data.map((d) => ({ name: `${d.value} ${d.key}` }))
+    const legendData: Array<LegendData> = props.data.map((d) => ({ name: `${d.value} ${d.key}`, link: d.link }))
     const total = props.data.reduce((a, b) => a + b.value, 0)
     /* istanbul ignore next */
     const primary = props.data.find((d) => d.isPrimary) || { key: '', value: 0 }
@@ -77,6 +98,7 @@ export function AcmDonutChart(props: {
                     constrainToVisibleArea={true}
                     data={chartData}
                     legendData={legendData}
+                    legendComponent={buildLegendWithLinks(legendData)}
                     labels={({ datum }) => `${datum.x}: ${(datum.y / total) * 100}%`}
                     padding={{
                         bottom: 20,


### PR DESCRIPTION
**Issue:** https://github.com/open-cluster-management/backlog/issues/8814

### Description:
Adds an optional `link` to be added in the legend.  This will be used to link to the search page.

(Mouse was over `1 Non-compliant`.  Check link in the browsers bottom left corner.)
![image](https://user-images.githubusercontent.com/4671325/106525625-433d9e00-64b2-11eb-94a9-85e13725b614.png)
