### PR TITLE
update cloud.RedHat name

### DIFF
--- a/src/AcmProvider/index.tsx
+++ b/src/AcmProvider/index.tsx
@@ -16,7 +16,7 @@ export enum Provider {
 }
 
 export const ProviderShortTextMap = {
-    [Provider.redhatcloud]: 'cloud.redhat.com',
+    [Provider.redhatcloud]: 'OCM',
     [Provider.openstack]: 'OpenStack',
     [Provider.aws]: 'Amazon',
     [Provider.gcp]: 'Google',
@@ -28,7 +28,7 @@ export const ProviderShortTextMap = {
 }
 
 export const ProviderLongTextMap = {
-    [Provider.redhatcloud]: 'cloud.redhat.com',
+    [Provider.redhatcloud]: 'Red Hat OpenShift Cluster Manager',
     [Provider.openstack]: 'Red Hat OpenStack',
     [Provider.aws]: 'Amazon Web Services',
     [Provider.gcp]: 'Google Cloud Platform',


### PR DESCRIPTION
Updating the name used by cloud.Red Hat.com. It is used to add provider connections. Name was approved by Joy.

https://app.zenhub.com/workspaces/applifecycle-issue-tracker-5e480a1f17e47394a67447b9/issues/open-cluster-management/backlog/6592