### PR TITLE
Skip delete tag function if there are no tags present in search bar

### DIFF
--- a/src/AcmSearchbar/AcmSearchbar.test.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { axe } from 'jest-axe'
 import React from 'react'
@@ -78,9 +78,15 @@ describe('AcmSearchbar', () => {
         expect(getByText('namespace:default')).toBeInTheDocument()
     })
 
+    test('validates delete search tag function - no tags present', async () => {
+        const { queryByText, getByRole } = render(<BlankSearchbar />)
+        userEvent.click(getByRole('combobox'))
+        fireEvent.keyDown(getByRole('combobox'), { key: 'Backspace', code: 'Backspace' })
+        expect(queryByText('Search items')).toBeInTheDocument()
+    })
+
     test('validates delete search tag function - whole tag', async () => {
         const { getByText, queryByText } = render(<PrefilledSearchbar />)
-        expect(getByText('namespace:default')).toBeInTheDocument()
         userEvent.click(getByText('namespace:default'))
         expect(queryByText('namespace:default')).not.toBeInTheDocument()
     })

--- a/src/AcmSearchbar/AcmSearchbar.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.tsx
@@ -51,18 +51,20 @@ export function AcmSearchbar(props: AcmSearchbarProps) {
                     return suggestion.name.toLowerCase().includes(query.toLowerCase())
                 }}
                 onDelete={(idx: number) => {
-                    // need to check if there are 2+ values @ tag[idx] - if there are we only delete the last one
-                    const tagToDelete = searchbarTags[idx]
-                    if (tagToDelete.name.includes(',')) {
-                        const values = tagToDelete.name.split(',')
-                        values.splice(values.length - 1, 1)
-                        tagToDelete.name = values.join(',')
-                    } else {
-                        searchbarTags.splice(idx, 1)
+                    if (idx >= 0) {
+                        // need to check if there are 2+ values @ tag[idx] - if there are we only delete the last one
+                        const tagToDelete = searchbarTags[idx]
+                        if (tagToDelete.name.includes(',')) {
+                            const values = tagToDelete.name.split(',')
+                            values.splice(values.length - 1, 1)
+                            tagToDelete.name = values.join(',')
+                        } else {
+                            searchbarTags.splice(idx, 1)
+                        }
+                        setCurrentQuery(searchbarTags.map((tag) => tag.name).join(' '))
+                        currentQueryCallback(searchbarTags.map((tag) => tag.name).join(' '))
+                        setSearchbarTags(searchbarTags)
                     }
-                    setCurrentQuery(searchbarTags.map((tag) => tag.name).join(' '))
-                    currentQueryCallback(searchbarTags.map((tag) => tag.name).join(' '))
-                    setSearchbarTags(searchbarTags)
                 }}
                 onAddition={(tag: DropdownSuggestionsProps) => {
                     if (


### PR DESCRIPTION
This fix skips the delete tag function when no tags are present in searchbar component