### PR TITLE
Add optional color scheme to donut chart

### DIFF
--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
@@ -105,7 +105,7 @@ export function AcmDonutChart(props: {
                     constrainToVisibleArea={true}
                     data={chartData}
                     legendData={legendData}
-                    legendComponent={buildLegendWithLinks(legendData)}
+                    legendComponent={buildLegendWithLinks(legendData, props.colorScale)}
                     labels={({ datum }) => `${datum.x}: ${((datum.y / total) * 100).toFixed(2)}%`}
                     padding={{
                         bottom: 20,

--- a/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
+++ b/src/AcmCharts/AcmDonutChart/AcmDonutChart.tsx
@@ -70,11 +70,17 @@ const LegendLabel = ({ ...props }: { datum?: Data }) => {
     )
 }
 
-function buildLegendWithLinks(legendData: Array<LegendData>) {
-    return <ChartLegend data={legendData} labelComponent={<LegendLabel />} />
+function buildLegendWithLinks(legendData: Array<LegendData>, colorScale?: string[]) {
+    return <ChartLegend data={legendData} labelComponent={<LegendLabel />} colorScale={colorScale} />
 }
 
-export function AcmDonutChart(props: { title: string; description: string; data: Array<Data>; loading?: boolean }) {
+export function AcmDonutChart(props: {
+    title: string
+    description: string
+    data: Array<Data>
+    loading?: boolean
+    colorScale?: string[]
+}) {
     const chartData = props.data.map((d) => ({ x: d.key, y: d.value }))
     const legendData: Array<LegendData> = props.data.map((d) => ({ name: `${d.value} ${d.key}`, link: d.link }))
     const total = props.data.reduce((a, b) => a + b.value, 0)
@@ -111,6 +117,9 @@ export function AcmDonutChart(props: { title: string; description: string; data:
                     subTitle={primary.key}
                     width={/* istanbul ignore next */ viewWidth < 376 ? viewWidth : 376}
                     height={/* istanbul ignore next */ viewWidth < 376 ? 150 : 200}
+                    // Devs can supply an array of colors the donut chart will use ex: ['#E62325', '#EC7A08', '#F4C145', '#2B9AF3', '#72767B']
+                    // Defaults to blue theme
+                    colorScale={props.colorScale}
                 />
             </div>
         </Card>


### PR DESCRIPTION
Allow devs to specify a color scheme for Donut chart component.
Default:
![Screen Shot 2021-02-23 at 4 59 10 PM](https://user-images.githubusercontent.com/14047925/108913800-77f7cd80-75f8-11eb-901e-87e0f47a9388.png)

With Scheme:
![Screen Shot 2021-02-23 at 5 01 25 PM](https://user-images.githubusercontent.com/14047925/108914024-c907c180-75f8-11eb-9221-07275fb4c1c8.png)

Donut chart prop would look like the following to change the theme (otherwise `colorScale` can be left undefined for default theme):
```
<AcmDonutChart
    title="Pods"
    description="Overview of pod count and status"
    data={podData}
    colorScale={['#E62325', '#EC7A08', '#F4C145', '#2B9AF3', '#72767B']} />
```