### PR TITLE
Dynamically set card column width within Grid layout based on number …

### DIFF
--- a/src/AcmCountCard/AcmCountCardSection.tsx
+++ b/src/AcmCountCard/AcmCountCardSection.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Grid, GridItem, Skeleton } from '@patternfly/react-core'
+import { Grid, GridItem, Skeleton, gridItemSpanValueShape } from '@patternfly/react-core'
 import { ExclamationCircleIcon } from '@patternfly/react-icons'
 import { AcmExpandableCard } from '../AcmExpandable'
 import { makeStyles } from '@material-ui/styles'
@@ -72,9 +72,14 @@ export type AcmCountCardSectionCard = {
 
 export const AcmCountCardSection = (props: AcmCountCardSection) => {
     const classes = useStyles()
+    const cardCount = props.cards.length
+    // Grid uses a 12 column layout - here we find the number of coulumns to evenly use per item
+    // If 12 / cardCount doesnt come out to a whole number we round up and the extra card will be displayed on a second row
+    const gridNum = Math.ceil(12 / cardCount) as gridItemSpanValueShape
+
     return (
         <AcmExpandableCard title={props.title} className={classes.section} id={props.id}>
-            <Grid sm={4}>
+            <Grid sm={gridNum}>
                 {props.cards.map((card, i) => {
                     return (
                         <GridItem key={i}>


### PR DESCRIPTION
…of cards in section

Evenly space cards within the section:
![Screen Shot 2021-02-24 at 9 44 25 AM](https://user-images.githubusercontent.com/14047925/109017324-0f0a6700-7685-11eb-92d3-6f7d38b490cb.png)

![Screen Shot 2021-02-24 at 9 45 23 AM](https://user-images.githubusercontent.com/14047925/109017334-12055780-7685-11eb-9262-6337ac2ee9f7.png)
