### PR TITLE
Fix fuzzy sort

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -141,7 +141,7 @@ describe('AcmTable', () => {
             <Table items={exampleData.slice(0, 8)} gridBreakPoint={TableGridBreakpoint.none} />
         )
         expect(container.querySelector('.pf-c-pagination')).toBeInTheDocument()
-        expect(container.querySelector('.pf-c-table__sort-indicator')).toBeInTheDOM()
+        expect(container.querySelector('.pf-c-table__sort-indicator')).toBeInTheDocument()
     })
     test('can support table actions', () => {
         const { getByText } = render(<Table />)

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -281,8 +281,6 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     const filtered = useMemo<T[]>(() => {
         if (search && search !== '' && searchItems) {
             const fuse = new Fuse(searchItems, {
-                includeScore: true,
-                shouldSort: true,
                 threshold: 0.3,
                 keys: columns
                     .map((column, i) => (column.search ? `column-${i}` : undefined))
@@ -305,8 +303,8 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             : sort
 
     const sorted = useMemo<T[]>(() => {
-        if (sort) {
-            const compare = columns[(sort && sort.index ? sort.index : 0) - sortIndexOffset].sort
+        if (sort && sort.index !== undefined) {
+            const compare = columns[sort.index - sortIndexOffset].sort
             const sorted: T[] = [...filtered]
             /* istanbul ignore else */
             if (compare) {

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -282,6 +282,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         if (search && search !== '' && searchItems) {
             const fuse = new Fuse(searchItems, {
                 includeScore: true,
+                shouldSort: true,
                 threshold: 0.3,
                 keys: columns
                     .map((column, i) => (column.search ? `column-${i}` : undefined))


### PR DESCRIPTION
Code to initially sort by first column without showing sort indicator was being applied during filtering, instead of allowing the fuse score sort order to be used.