### PR TITLE
fix divider borders disappearing on scaling

### DIFF
--- a/src/AcmPage/AcmPage.tsx
+++ b/src/AcmPage/AcmPage.tsx
@@ -114,12 +114,11 @@ export function AcmPageHeader(props: {
                 </Split>
             </PageSection>
             {props.navigation && (
-                <Fragment>
-                    <Divider component="div" />
+                <div style={{ borderTop: 'thin solid #00000022' }}>
                     <PageSection variant={PageSectionVariants.light} type="nav" style={{ paddingTop: 0 }}>
                         {props.navigation}
                     </PageSection>
-                </Fragment>
+                </div>
             )}
         </Fragment>
     )
@@ -172,8 +171,7 @@ export function AcmPageContent(props: AcmPageContentProps) {
         <AcmErrorBoundary key={props.id}>
             <AcmAlertProvider>
                 <AcmAlertGroup isInline canClose />
-                <Divider component="div" />
-                <AcmScrollable>{props.children}</AcmScrollable>
+                <AcmScrollable borderTop>{props.children}</AcmScrollable>
             </AcmAlertProvider>
         </AcmErrorBoundary>
     )

--- a/src/AcmPage/AcmPage.tsx
+++ b/src/AcmPage/AcmPage.tsx
@@ -6,7 +6,6 @@ import {
     Button,
     Card,
     CardBody,
-    Divider,
     Page,
     PageSection,
     PageSectionVariants,


### PR DESCRIPTION
A 1 px <Divider/> will disappear at certain browser page scaling

The fix is to use a thin or 1px border at the bottom or top of an area, and it always shows up at all scaling.