### PR TITLE
fix kube version parse

### DIFF
--- a/src/AcmHeader/AcmHeader.tsx
+++ b/src/AcmHeader/AcmHeader.tsx
@@ -65,9 +65,9 @@ function launchToOCP(urlSuffix: string) {
 
 function checkOCPVersion(switcherExists: (arg0: boolean) => void) {
     if (process.env.NODE_ENV === 'test') return
-    api<{ data: { gitVersion: string } }>('/multicloud/version/')
-        .then(({ data }) => {
-            if (parseFloat(data.gitVersion.substr(1, 4)) >= 1.2) {
+    api<{ gitVersion: string }>('/multicloud/version/')
+        .then(({ gitVersion }) => {
+            if (parseFloat(gitVersion.substr(1, 4)) >= 1.2) {
                 switcherExists(true)
             } else {
                 switcherExists(false)


### PR DESCRIPTION
previously checkOCPVersion was parsing the data returned by the /version api incorrectly, causing the perspective switcher to not be shown even on newer versions