### PR TITLE
Alterations to AcmTiles for new credential wizard [WIP]

### DIFF
--- a/src/AcmTile/AcmTile.stories.tsx
+++ b/src/AcmTile/AcmTile.stories.tsx
@@ -36,21 +36,6 @@ export const Tile = () => {
                 flex: '1 0 0',
             },
         },
-        testIcon: {
-            '& tile__icon': {
-                display: 'flex',
-                height: '50%',
-                width: '50%',
-                margin: '0 auto',
-                overflow: 'hidden',
-                icon: {
-                    height: '100%',
-                    margin: '0 5rem',
-                    cursor: 'pointer',
-                    flex: '1 0 0',
-                },
-            },
-        },
     })
 
     const classes = useStyles()

--- a/src/AcmTile/AcmTile.stories.tsx
+++ b/src/AcmTile/AcmTile.stories.tsx
@@ -4,6 +4,10 @@ import '@patternfly/react-core/dist/styles/base.css'
 import React, { useState } from 'react'
 import { Meta } from '@storybook/react'
 import { AcmTile } from './AcmTile'
+import { Grid, GridItem } from '@patternfly/react-core'
+import { AcmIcon, AcmIconVariant } from '../AcmIcons/AcmIcons'
+import AnsibleIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon'
+import { makeStyles } from '@material-ui/styles'
 
 const meta: Meta = {
     title: 'Tile',
@@ -17,6 +21,39 @@ export default meta
 
 export const Tile = () => {
     const [selected, toggleSelected] = useState<boolean>(false)
+
+    const useStyles = makeStyles({
+        iconClass: {
+            display: 'flex',
+            height: '50%',
+            width: '50%',
+            margin: '0 auto',
+            overflow: 'hidden',
+            icon: {
+                height: '100%',
+                margin: '0 5rem',
+                cursor: 'pointer',
+                flex: '1 0 0',
+            },
+        },
+        testIcon: {
+            '& tile__icon': {
+                display: 'flex',
+                height: '50%',
+                width: '50%',
+                margin: '0 auto',
+                overflow: 'hidden',
+                icon: {
+                    height: '100%',
+                    margin: '0 5rem',
+                    cursor: 'pointer',
+                    flex: '1 0 0',
+                },
+            },
+        },
+    })
+
+    const classes = useStyles()
 
     return (
         <div>
@@ -34,6 +71,23 @@ export const Tile = () => {
                 onClick={() => toggleSelected(!selected)}
                 relatedResourceData={{ count: 1, kind: 'veryShort' }}
             />
+
+            <Grid span={1} md={1} hasGutter={false}>
+                <GridItem md={1}>
+                    <AcmTile title="Ansible Tower" isStacked={true} icon={<AnsibleIcon />} />
+                </GridItem>
+                <GridItem>
+                    <AcmTile
+                        title="Infrastructure Provider"
+                        isStacked={true}
+                        AcmIcon={
+                            <div className={classes.iconClass}>
+                                <AcmIcon icon={AcmIconVariant.cloud}></AcmIcon>
+                            </div>
+                        }
+                    />
+                </GridItem>
+            </Grid>
         </div>
     )
 }

--- a/src/AcmTile/AcmTile.test.tsx
+++ b/src/AcmTile/AcmTile.test.tsx
@@ -4,6 +4,8 @@ import React from 'react'
 import { render } from '@testing-library/react'
 import { axe } from 'jest-axe'
 import { AcmTile } from './AcmTile'
+import { AcmIcon, AcmIconVariant } from '../AcmIcons/AcmIcons'
+import AnsibleIcon from '@patternfly/react-icons/dist/js/icons/ansibeTower-icon'
 
 describe('AcmTile', () => {
     const LoadingTile = () => {
@@ -26,6 +28,22 @@ describe('AcmTile', () => {
         return <AcmTile isSelected={false} relatedResourceData={{ count: 9999, kind: 'pod' }} title={''} />
     }
 
+    const DisabledTile = () => {
+        return <AcmTile title="Infrastructure Provider" isStacked={true} isDisabled={true} />
+    }
+    const IconTile = () => {
+        return (
+            <AcmTile
+                title="Ansible Tower"
+                isStacked={true}
+                AcmIcon={<AcmIcon icon={AcmIconVariant.cloud}></AcmIcon>}
+                icon={<AnsibleIcon />}
+                isDisabled={true}
+                isDisplayLarge={true}
+            />
+        )
+    }
+
     test('renders loading tile component', () => {
         const { queryByText } = render(<LoadingTile />)
         expect(queryByText('testing')).not.toBeInTheDocument()
@@ -43,6 +61,15 @@ describe('AcmTile', () => {
     test('renders default tile component', () => {
         const { getByText } = render(<DefaultTile />)
         expect(getByText('Tile title')).toBeInTheDocument()
+    })
+    test('renders disabled tile component', () => {
+        const { getByText } = render(<DisabledTile />)
+        expect(getByText('Infrastructure Provider')).toBeInTheDocument()
+    })
+    test('renders tile component with icons', () => {
+        const { getByText, getByRole } = render(<IconTile />)
+        expect(getByText('Ansible Tower')).toBeInTheDocument()
+        expect(getByRole('presentation')).toBeInTheDocument()
     })
     test('has zero accessibility defects - unselected', async () => {
         const { container } = render(<DefaultTile />)

--- a/src/AcmTile/AcmTile.tsx
+++ b/src/AcmTile/AcmTile.tsx
@@ -77,9 +77,7 @@ export function AcmTile(props: AcmTileProps) {
         )
     }
     return (
-        <Tile {...props} ref={null}>
-            {' '}
-        </Tile>
+        <Tile {...props} ref={null} />
     )
 }
 

--- a/src/AcmTile/AcmTile.tsx
+++ b/src/AcmTile/AcmTile.tsx
@@ -76,9 +76,7 @@ export function AcmTile(props: AcmTileProps) {
             </Tile>
         )
     }
-    return (
-        <Tile {...props} ref={null} />
-    )
+    return <Tile {...props} ref={null} />
 }
 
 const Tile: React.FunctionComponent<AcmTileProps> = ({

--- a/src/AcmTile/AcmTile.tsx
+++ b/src/AcmTile/AcmTile.tsx
@@ -1,9 +1,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import React from 'react'
-import { Skeleton, Tile, TileProps } from '@patternfly/react-core'
+import React, { ReactNode } from 'react'
+import { Skeleton, TileProps } from '@patternfly/react-core'
 import { makeStyles } from '@material-ui/styles'
 import '@patternfly/react-core/dist/styles/base.css'
+import styles from '@patternfly/react-styles/css/components/Tile/tile'
+import { css } from '@patternfly/react-styles'
 
 type AcmTileProps = TileProps & {
     loading?: boolean
@@ -11,6 +13,7 @@ type AcmTileProps = TileProps & {
         count: number
         kind: string
     }
+    AcmIcon?: ReactNode
 }
 
 const useStyles = makeStyles({
@@ -73,5 +76,42 @@ export function AcmTile(props: AcmTileProps) {
             </Tile>
         )
     }
-    return <Tile {...props} ref={null} />
+    return (
+        <Tile {...props} ref={null}>
+            {' '}
+        </Tile>
+    )
 }
+
+const Tile: React.FunctionComponent<AcmTileProps> = ({
+    AcmIcon,
+    children,
+    title,
+    icon,
+    isStacked,
+    isSelected,
+    isDisabled,
+    isDisplayLarge,
+    className,
+    ...props
+}: AcmTileProps) => (
+    <div
+        className={css(
+            styles.tile,
+            isSelected && styles.modifiers.selected,
+            isDisabled && styles.modifiers.disabled,
+            isDisplayLarge && styles.modifiers.displayLg,
+            className
+        )}
+        tabIndex={0}
+        {...props}
+    >
+        <div className={css(styles.tileHeader, isStacked && styles.modifiers.stacked)}>
+            {AcmIcon}
+            {icon && <div className={css(styles.tileIcon)}>{icon}</div>}
+            <div className={css(styles.tileTitle)}>{title}</div>
+        </div>
+        {children && <div className={css(styles.tileBody)}>{children}</div>}
+    </div>
+)
+Tile.displayName = 'Tile'


### PR DESCRIPTION
Alterations 

- Contents of PF Tile component have been moved to AcmTile to allow direct configuration.
- Allows for AcmIcon component to be passed directly to AcmTile (is not currently compatible with AcmIcon when passed as a "icon" prop)
