### PR TITLE
Table grouping

### DIFF
--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -389,6 +389,27 @@ export const exampleSubData: IExampleSubData[] = [
         lastName: 'Solo',
         color: 'blue',
     },
+    {
+        uid: 25,
+        suid: '1',
+        firstName: 'Sally',
+        lastName: 'Aspen',
+        color: 'black',
+    },
+    {
+        uid: 25,
+        suid: '2',
+        firstName: 'Kelly',
+        lastName: 'Williams',
+        color: 'yellow',
+    },
+    {
+        uid: 25,
+        suid: '3',
+        firstName: 'Kurt',
+        lastName: 'Daley',
+        color: 'pink',
+    },
 ]
 
 export const exampleData: IExampleData[] = [

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -59,7 +59,7 @@ export function TableStory(args: Record<string, unknown>) {
     )
 }
 
-export function TableWithExpand(args: Record<string, unknown>) {
+export function TableExpandable(args: Record<string, unknown>) {
     const [items, setItems] = useState<IExampleData[]>(exampleData.slice(0, 105))
     return (
         <div style={{ height: '100vh' }}>

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -21,7 +21,7 @@ interface IExampleData {
 export default {
     title: 'Table',
     component: AcmTable,
-    excludeStories: ['exampleData', 'exampleSubData'],
+    excludeStories: ['TableStory', 'exampleData', 'exampleSubData'],
     argTypes: {
         'Include tableActions': { control: { type: 'boolean' }, defaultValue: true },
         'Include rowActions': { control: { type: 'boolean' }, defaultValue: true },
@@ -45,7 +45,7 @@ export function Table(args: Record<string, unknown>) {
     )
 }
 
-function TableStory(args: Record<string, unknown>) {
+export function TableStory(args: Record<string, unknown>) {
     const [items, setItems] = useState<IExampleData[]>(exampleData.slice(0, 105))
     return (
         <AcmTable<IExampleData>

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -21,14 +21,7 @@ interface IExampleData {
 export default {
     title: 'Table',
     component: AcmTable,
-    excludeStories: [
-        'TableStory',
-        'TableEmptyStory',
-        'TableLoadingStory',
-        'exampleData',
-        'exampleSubData',
-        'commonProperties',
-    ],
+    excludeStories: ['exampleData', 'exampleSubData'],
     argTypes: {
         'Include tableActions': { control: { type: 'boolean' }, defaultValue: true },
         'Include rowActions': { control: { type: 'boolean' }, defaultValue: true },
@@ -52,7 +45,7 @@ export function Table(args: Record<string, unknown>) {
     )
 }
 
-export function TableStory(args: Record<string, unknown>) {
+function TableStory(args: Record<string, unknown>) {
     const [items, setItems] = useState<IExampleData[]>(exampleData.slice(0, 105))
     return (
         <AcmTable<IExampleData>
@@ -130,6 +123,38 @@ export function TableWithExpand(args: Record<string, unknown>) {
         </div>
     )
 }
+export function TableGrouped(args: Record<string, unknown>) {
+    return (
+        <div style={{ height: '100vh' }}>
+            <AcmPage>
+                <AcmPageHeader title="AcmTable" />
+                <AcmPageContent id="table">
+                    <PageSection variant="light" isFilled>
+                        <TableGroupedStory {...args} />
+                    </PageSection>
+                </AcmPageContent>
+            </AcmPage>
+        </div>
+    )
+}
+
+function TableGroupedStory(args: Record<string, unknown>) {
+    const [items, setItems] = useState<IExampleData[]>(exampleData.slice(0, 105))
+    return (
+        <AcmTable<IExampleData>
+            plural="addresses"
+            items={items}
+            columns={columns}
+            keyFn={(item: IExampleData) => item.uid.toString()}
+            groupFn={(item: IExampleData) => {
+                const provider = getProviderForItem(item)
+                return provider !== Provider.other ? provider : null
+            }}
+            {...commonProperties(args, (items) => setItems(items), items)}
+            gridBreakPoint={TableGridBreakpoint.none}
+        />
+    )
+}
 
 export function TableEmpty(args: Record<string, unknown>) {
     return (
@@ -146,7 +171,7 @@ export function TableEmpty(args: Record<string, unknown>) {
     )
 }
 
-export function TableEmptyStory(args: Record<string, unknown>) {
+function TableEmptyStory(args: Record<string, unknown>) {
     const [items, setItems] = useState<IExampleData[]>()
     return (
         <AcmTable<IExampleData>
@@ -174,7 +199,7 @@ export function TableLoading(args: Record<string, unknown>) {
     )
 }
 
-export function TableLoadingStory(args: Record<string, unknown>) {
+function TableLoadingStory(args: Record<string, unknown>) {
     const [items, setItems] = useState<IExampleData[]>()
     return (
         <AcmTable<IExampleData>
@@ -187,7 +212,7 @@ export function TableLoadingStory(args: Record<string, unknown>) {
     )
 }
 
-export function commonProperties(
+function commonProperties(
     args: Record<string, unknown>,
     setItems: (items: IExampleData[]) => void,
     items: IExampleData[] | undefined
@@ -254,6 +279,28 @@ export function commonProperties(
     }
 }
 
+function getProviderForItem(item: IExampleData) {
+    const chr = item.last_name.charCodeAt(0)
+    switch (chr % 8) {
+        case 0:
+            return Provider.aws
+        case 1:
+            return Provider.azure
+        case 2:
+            return Provider.baremetal
+        case 3:
+            return Provider.gcp
+        case 4:
+            return Provider.ibm
+        case 5:
+            return Provider.other
+        case 6:
+            return Provider.openstack
+        default:
+            return Provider.vmware
+    }
+}
+
 const columns: IAcmTableColumn<IExampleData>[] = [
     {
         header: 'First Name',
@@ -297,27 +344,7 @@ const columns: IAcmTableColumn<IExampleData>[] = [
     },
     {
         header: 'Provider',
-        cell: (item) => {
-            const chr = item.last_name.charCodeAt(0)
-            switch (chr % 8) {
-                case 0:
-                    return <AcmInlineProvider provider={Provider.aws} />
-                case 1:
-                    return <AcmInlineProvider provider={Provider.azure} />
-                case 2:
-                    return <AcmInlineProvider provider={Provider.baremetal} />
-                case 3:
-                    return <AcmInlineProvider provider={Provider.gcp} />
-                case 4:
-                    return <AcmInlineProvider provider={Provider.ibm} />
-                case 5:
-                    return <AcmInlineProvider provider={Provider.other} />
-                case 6:
-                    return <AcmInlineProvider provider={Provider.openstack} />
-                default:
-                    return <AcmInlineProvider provider={Provider.vmware} />
-            }
-        },
+        cell: (item) => <AcmInlineProvider provider={getProviderForItem(item)} />,
     },
     {
         header: 'Status',

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -452,8 +452,8 @@ describe('AcmTable', () => {
                 plural="addresses"
                 showToolbar={false}
                 items={exampleData.slice(0, 10)}
-                addSubRows={(item: IExampleData, itemIndex) => {
-                    if (itemIndex === 0) {
+                addSubRows={(item: IExampleData) => {
+                    if (item.uid === 1) {
                         return [
                             {
                                 cells: [

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -38,6 +38,7 @@ describe('AcmTable', () => {
             useExtraToolbarControls?: boolean
             useSearch?: boolean
             transforms?: boolean
+            groupFn?: (item: IExampleData) => string | null
             gridBreakPoint?: TableGridBreakpoint
         } & Partial<AcmTableProps<IExampleData>>
     ) => {
@@ -503,5 +504,12 @@ describe('AcmTable', () => {
         )
         userEvent.click(getByTestId('expandable-toggle0'))
         expect(getByTestId('expanded')).toBeInTheDocument()
+    })
+    test('renders with grouping', () => {
+        const { getByTestId } = render(
+            // Group some items by name and some by gender to test single and multiple-item groups
+            <Table groupFn={(item) => (item.uid < 50 ? item.firstName : item.gender)} />
+        )
+        userEvent.click(getByTestId('expandable-toggle0'))
     })
 })

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -435,7 +435,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             let isOpen: boolean | undefined = undefined
             if (group) {
                 // Only group if the next item is also part of the group
-                if (subRows?.length) {
+                if (subRows!.length) {
                     isOpen = !!openGroups[group]
                 }
             } else {

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -434,7 +434,10 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
             if (group) {
                 if (groupMap[group] === undefined) {
                     groupMap[group] = i
-                    isOpen = !!openGroups[group]
+                    // Only group if the next item is also part of the group
+                    if (i + 1 < paged.length && paged[i + 1].group === group) {
+                        isOpen = !!openGroups[group]
+                    }
                 } else {
                     parent = groupMap[group]
                 }


### PR DESCRIPTION
Adds support for grouping table rows. In the storybook example, rows are grouped by provider, unless the provider is Other.
(Support for having a group summary row to come in a separate PR.)

![image](https://user-images.githubusercontent.com/42188127/113937632-73adfb00-97c7-11eb-94d0-f36ac333b439.png)
