### PR TITLE
Update table customizations

### DIFF
--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -29,7 +29,7 @@ export default {
         'Include extraToolbarControls': { control: { type: 'boolean' }, defaultValue: true },
         'Use groupSummaryFn': { control: { type: 'boolean' }, defaultValue: false },
         'Remove borders': { control: { type: 'boolean' }, defaultValue: false },
-        'Pagination at bottom': { control: { type: 'boolean' }, defaultValue: false }
+        'Pagination at bottom': { control: { type: 'boolean' }, defaultValue: false },
     },
 }
 

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -29,6 +29,7 @@ export default {
         'Include extraToolbarControls': { control: { type: 'boolean' }, defaultValue: true },
         'Use groupSummaryFn': { control: { type: 'boolean' }, defaultValue: false },
         'Remove borders': { control: { type: 'boolean' }, defaultValue: false },
+        'Pagination at bottom': { control: { type: 'boolean' }, defaultValue: false }
     },
 }
 
@@ -242,6 +243,7 @@ function commonProperties(
     items: IExampleData[] | undefined
 ) {
     return {
+        paginationAtBottom: !!args['Pagination at bottom'],
         noBorders: !!args['Remove borders'],
         tableActions: args['Include tableActions']
             ? [

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -156,9 +156,17 @@ describe('AcmTable', () => {
         const { container } = render(<Table useTableActions={false} useRowActions={false} />)
         expect(container.querySelector('table')).toBeInTheDocument()
     })
+    test('renders pagination at the bottom when paginationAtBottom is set', () => {
+        const { container } = render(<Table items={exampleData} paginationAtBottom />)
+        expect(container.querySelector('div.pf-c-toolbar div.pf-c-pagination')).toBeNull()
+        expect(
+            container.querySelector('div.pf-c-toolbar ~ div.pf-c-toolbar__item > div.pf-c-pagination')
+        ).toBeInTheDocument()
+    })
     test('renders pagination with autoHidePagination when more that perPage items', () => {
         const { container } = render(<Table items={exampleData} autoHidePagination />)
-        expect(container.querySelector('.pf-c-pagination')).toBeInTheDocument()
+        expect(container.querySelector('div.pf-c-toolbar div.pf-c-pagination')).toBeInTheDocument()
+        expect(container.querySelector('div.pf-c-toolbar ~ div.pf-c-toolbar__item > div.pf-c-pagination')).toBeNull()
     })
     test('hides pagination with autoHidePagination when less than perPage items', () => {
         const { container } = render(<Table items={exampleData.slice(0, 8)} autoHidePagination />)

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -30,6 +30,7 @@ describe('AcmTable', () => {
     const deleteAction = jest.fn()
     const sortFunction = jest.fn()
     const testItems = exampleData.slice(0, 105)
+    const placeholderString = 'Search'
     const Table = (
         props: {
             noBorders?: boolean
@@ -37,6 +38,7 @@ describe('AcmTable', () => {
             useRowActions?: boolean
             useBulkActions?: boolean
             useExtraToolbarControls?: boolean
+            searchPlaceholder?: string
             useSearch?: boolean
             transforms?: boolean
             groupFn?: (item: IExampleData) => string | null
@@ -224,11 +226,19 @@ describe('AcmTable', () => {
         userEvent.click(getByText('Delete item'))
         expect(deleteAction).toHaveBeenCalled()
     })
+    test('can customize search placeholder', () => {
+        const customPlaceholder = 'Other placeholder'
+        const { container } = render(<Table searchPlaceholder={customPlaceholder} />)
+        expect(container.querySelector('div.pf-c-toolbar input.pf-c-search-input__text-input')).toHaveAttribute(
+            'placeholder',
+            customPlaceholder
+        )
+    })
     test('can be searched', () => {
         const { getByPlaceholderText, queryByText, getByLabelText, getByText, container } = render(<Table />)
 
         // verify manually deleting search, resets table with first column sorting
-        userEvent.type(getByPlaceholderText('Search'), 'B{backspace}')
+        userEvent.type(getByPlaceholderText(placeholderString), 'B{backspace}')
         expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Abran')
 
         // sort by non-default column (UID)
@@ -236,8 +246,8 @@ describe('AcmTable', () => {
         expect(container.querySelector('tbody tr:first-of-type [data-label="UID"]')).toHaveTextContent('1')
 
         // search for 'Female'
-        expect(getByPlaceholderText('Search')).toBeInTheDocument()
-        userEvent.type(getByPlaceholderText('Search'), 'Female')
+        expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
+        userEvent.type(getByPlaceholderText(placeholderString), 'Female')
         expect(queryByText('57 / 105')).toBeVisible()
 
         // clear filter
@@ -249,8 +259,8 @@ describe('AcmTable', () => {
         expect(container.querySelector('tbody tr:first-of-type [data-label="UID"]')).toHaveTextContent('1')
 
         // search for '.org'
-        expect(getByPlaceholderText('Search')).toBeInTheDocument()
-        userEvent.type(getByPlaceholderText('Search'), '.org')
+        expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
+        userEvent.type(getByPlaceholderText(placeholderString), '.org')
         expect(queryByText('7 / 105')).toBeVisible()
 
         // verify last sort order ignored
@@ -329,8 +339,8 @@ describe('AcmTable', () => {
     test('should show the empty state when filtered results', () => {
         const { getByPlaceholderText, queryByText, getByText } = render(<Table />)
         expect(queryByText('No results found')).toBeNull()
-        expect(getByPlaceholderText('Search')).toBeInTheDocument()
-        userEvent.type(getByPlaceholderText('Search'), 'NOSEARCHRESULTS')
+        expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
+        userEvent.type(getByPlaceholderText(placeholderString), 'NOSEARCHRESULTS')
         expect(queryByText('No results found')).toBeVisible()
         getByText('Clear all filters').click()
         expect(queryByText('No results found')).toBeNull()
@@ -407,8 +417,8 @@ describe('AcmTable', () => {
         const { getByPlaceholderText, queryByText, getByLabelText, getByText, container } = render(<Table />)
 
         // search for 'ABSOLUTELYZEROMATCHES'
-        expect(getByPlaceholderText('Search')).toBeInTheDocument()
-        userEvent.type(getByPlaceholderText('Search'), 'ABSOLUTELYZEROMATCHES')
+        expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
+        userEvent.type(getByPlaceholderText(placeholderString), 'ABSOLUTELYZEROMATCHES')
         expect(queryByText('0 / 105')).toBeVisible()
 
         // change sort during filter (Last Name)
@@ -505,8 +515,8 @@ describe('AcmTable', () => {
         )
         userEvent.click(getByTestId('expandable-toggle0'))
         // search for 'Male'
-        expect(getByPlaceholderText('Search')).toBeInTheDocument()
-        userEvent.type(getByPlaceholderText('Search'), 'Male')
+        expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
+        userEvent.type(getByPlaceholderText(placeholderString), 'Male')
 
         // Run delete action for code coverage
         userEvent.click(getAllByLabelText('Actions')[0])

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -200,6 +200,7 @@ export interface AcmTableProps<T> {
     setPage?: (page: number) => void
     search?: string
     setSearch?: (search: string) => void
+    searchPlaceholder?: string
     sort?: ISortBy | undefined
     setSort?: (sort: ISortBy | undefined) => void
     showToolbar?: boolean
@@ -248,6 +249,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     const [stateSearch, stateSetSearch] = useState('')
     const search = props.search || stateSearch
     const setSearch = props.setSearch || stateSetSearch
+    const searchPlaceholder = props.searchPlaceholder || 'Search'
     const [stateSort, stateSetSort] = useState<ISortBy | undefined>(defaultSort)
     const sort = props.sort || stateSort
     const setSort = props.setSort || stateSetSort
@@ -648,7 +650,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                             <ToolbarGroup variant="filter-group">
                                 <ToolbarItem variant="search-filter">
                                     <SearchInput
-                                        placeholder="Search"
+                                        placeholder={searchPlaceholder}
                                         value={search}
                                         onChange={updateSearch}
                                         onClear={() => updateSearch('')}

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -197,6 +197,7 @@ export interface AcmTableProps<T> {
     emptyState?: ReactNode
     onSelect?: (items: T[]) => void
     page?: number
+    paginationAtBottom?: boolean
     setPage?: (page: number) => void
     search?: string
     setSearch?: (search: string) => void
@@ -562,6 +563,21 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         [page, perPage, setPage, setPerPage]
     )
 
+    const pagination = (
+        <ToolbarItem alignment={{ default: 'alignRight' }}>
+            <Pagination
+                itemCount={itemCount}
+                perPage={perPage}
+                page={page}
+                variant={PaginationVariant.top}
+                onSetPage={(_event, page) => setPage(page)}
+                onPerPageSelect={(_event, perPage) => updatePerPage(perPage)}
+                style={{ paddingRight: 0 }}
+                aria-label="Pagination top"
+            />
+        </ToolbarItem>
+    )
+
     const onSelect = useCallback(
         (_event: FormEvent, isSelected: boolean, rowId: number) => {
             /* istanbul ignore next */
@@ -711,20 +727,9 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                                 <ToolbarItem>{`${Object.keys(selected).length} selected`}</ToolbarItem>
                             </ToolbarGroup>
                         )}
-                        {(!props.autoHidePagination || filtered.length > perPage) && (
-                            <ToolbarItem alignment={{ default: 'alignRight' }}>
-                                <Pagination
-                                    itemCount={itemCount}
-                                    perPage={perPage}
-                                    page={page}
-                                    variant={PaginationVariant.top}
-                                    onSetPage={(_event, page) => setPage(page)}
-                                    onPerPageSelect={(_event, perPage) => updatePerPage(perPage)}
-                                    style={{ paddingRight: 0 }}
-                                    aria-label="Pagination top"
-                                />
-                            </ToolbarItem>
-                        )}
+                        {(!props.autoHidePagination || filtered.length > perPage) &&
+                            !props.paginationAtBottom &&
+                            pagination}
                     </ToolbarContent>
                 </Toolbar>
             )}
@@ -801,6 +806,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                             }
                         />
                     )}
+                    {(!props.autoHidePagination || filtered.length > perPage) && props.paginationAtBottom && pagination}
                 </Fragment>
             )}
         </Fragment>


### PR DESCRIPTION
- Add ability to customize the search placeholder (though the logic also prevents an empty string, which I think is okay)
- Add ability to position pagination controls below the table

(Let me know if anything is weird or wonky--this is literally my first TypeScript PR 🙂 )