### PR TITLE
Use ignoreLocation to search entire text

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -269,7 +269,7 @@ describe('AcmTable', () => {
         // search for '.org'
         expect(getByPlaceholderText(placeholderString)).toBeInTheDocument()
         userEvent.type(getByPlaceholderText(placeholderString), '.org')
-        expect(queryByText('7 / 105')).toBeVisible()
+        expect(queryByText('8 / 105')).toBeVisible()
 
         // verify last sort order ignored
         expect(container.querySelector('tbody tr:first-of-type [data-label="UID"]')).toHaveTextContent('8')

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -360,6 +360,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     }>(() => {
         if (search && search !== '') {
             const fuse = new Fuse(tableItems, {
+                ignoreLocation: true,
                 threshold: 0.3,
                 keys: columns
                     .map((column, i) => (column.search ? `column-${i}` : undefined))


### PR DESCRIPTION
Since the default `location` for Fuse is 0, the current `threshold`
setting limits matches to the first 30 characters of the text. As a
result, if a table cell has more than 30 characters, and a user copies
the entire text into the search, the filter will return 0 rows (when
users would expect *at least* the row they copied from).

See: https://fusejs.io/api/options.html#ignorelocation

An alternative fix would be to tweak the `location` and `threshold`
settings, or allow consumers to set them, but this is simpler for now.

Signed-off-by: Justin Kulikauskas <justin.kulikauskas@gmail.com>

Found with @dhaiducek when converting some tables in the grc-ui to the AcmTable.