### PR TITLE
Use full grid width if not given right items

### DIFF
--- a/src/AcmDescriptionList/AcmDescriptionList.test.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.test.tsx
@@ -15,11 +15,20 @@ describe('AcmDescriptionList', () => {
         { key: 'Namespace', value: 'cluster-namespace' },
         { key: 'Console URL', value: undefined },
     ]
+    const allItems = [...leftItems, ...rightItems]
     const DescriptionList = (props: { leftItems: ListItems[]; rightItems?: ListItems[] }) => (
         <AcmDescriptionList title="Details" leftItems={props.leftItems} rightItems={props.rightItems} />
     )
     test('renders', () => {
         const { queryByText, getByRole } = render(<DescriptionList leftItems={leftItems} rightItems={rightItems} />)
+        expect(queryByText('Details')).toBeInTheDocument()
+        expect(queryByText('Name')).toBeInTheDocument()
+        expect(queryByText('Namespace')).toBeInTheDocument()
+        userEvent.click(getByRole('button'))
+        expect(queryByText('Name')).toBeNull()
+    })
+    test('renders if only given left items', () => {
+        const { queryByText, getByRole } = render(<DescriptionList leftItems={allItems} />)
         expect(queryByText('Details')).toBeInTheDocument()
         expect(queryByText('Name')).toBeInTheDocument()
         expect(queryByText('Namespace')).toBeInTheDocument()

--- a/src/AcmDescriptionList/AcmDescriptionList.tsx
+++ b/src/AcmDescriptionList/AcmDescriptionList.tsx
@@ -35,7 +35,7 @@ export function AcmDescriptionList(props: {
     const classes = useStyles()
     return (
         <AcmExpandableCard title={props.title}>
-            <Grid sm={12} md={6}>
+            <Grid sm={12} md={props.rightItems ? 6 : 12}>
                 <GridItem className={classes.leftCol}>
                     <List items={props.leftItems} />
                 </GridItem>


### PR DESCRIPTION
Found this while moving some of the GRC pages over to using the shared components. With the current behavior of the AcmDescriptionList, this happens:

![current - col6 behavior](https://user-images.githubusercontent.com/44813129/117362038-c7743880-ae88-11eb-9088-6bd72104f9f1.png)

In our use case, since the list will only be one half of the page, we want to force it to have only one column, like this:

![proposed - col12 behavior](https://user-images.githubusercontent.com/44813129/117362260-073b2000-ae89-11eb-82f5-bb34f35d9375.png)

Note: to get code coverage for this I had to add a new test, which admittedly doesn't do much, and doesn't actually test the number of columns the grid items get... UI testing is still new to me, so I welcome any suggestions on how to do that better.