### PR TITLE
Idempotent build

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "lib"
     ],
     "scripts": {
-        "build": "tsc && cp -R src/assets lib/assets && copyfiles -u 1 src/**/*.css lib",
+        "build": "tsc && cp -R src/assets lib/ && copyfiles -u 1 src/**/*.css lib",
         "build:storybook": "cross-env NODE_ENV=production build-storybook --quiet",
         "lint": "npm run eslint",
         "eslint": "eslint --ext ts,tsx,js,jsx ./src --max-warnings=0",


### PR DESCRIPTION
Running `npm run build` twice results in duplicate assets.

After 1st run:
```
% tree lib/assets
lib/assets
├── EmptyPageIcon.png
├── Folder.png
├── IBM-Cloud.png
├── RHACM-Logo.min.svg
├── RHACM-Logo.svg
└── resource-destroyed.svg
```

After 2nd run:
```
% tree lib/assets
lib/assets
├── EmptyPageIcon.png
├── Folder.png
├── IBM-Cloud.png
├── RHACM-Logo.min.svg
├── RHACM-Logo.svg
├── assets
│   ├── EmptyPageIcon.png
│   ├── Folder.png
│   ├── IBM-Cloud.png
│   ├── RHACM-Logo.min.svg
│   ├── RHACM-Logo.svg
│   └── resource-destroyed.svg
└── resource-destroyed.svg
```
