### PR TITLE
Add optional initialSort prop to AcmTable

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -481,6 +481,19 @@ describe('AcmTable', () => {
     test('can be sorted with bulk actions', () => {
         sortTest(true)
     })
+    test('can be sorted by initialSort property', () => {
+        // initially sort by UID
+        const { getByText, container } = render(<Table initialSort={{ direction: 'asc', index: 5 }} />)
+        expect(container.querySelector('tbody tr:first-of-type [data-label="UID"]')).toHaveTextContent('1')
+
+        // verify clicking UID switches the direction
+        userEvent.click(getByText('UID'))
+        expect(container.querySelector('tbody tr:first-of-type [data-label="UID"]')).toHaveTextContent('105')
+
+        // verify clicking on other headers still works
+        userEvent.click(getByText('First Name'))
+        expect(container.querySelector('tbody tr:first-of-type [data-label="First Name"]')).toHaveTextContent('Abran')
+    })
     test('page size can be updated', () => {
         const { getByLabelText, getAllByLabelText, getByText, container } = render(
             <Table useExtraToolbarControls={false} useSearch={false} useTableActions={false} />

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -218,6 +218,7 @@ export interface AcmTableProps<T> {
     search?: string
     setSearch?: (search: string) => void
     searchPlaceholder?: string
+    initialSort?: ISortBy | undefined
     sort?: ISortBy | undefined
     setSort?: (sort: ISortBy | undefined) => void
     showToolbar?: boolean
@@ -246,11 +247,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         index: sortIndexOffset,
         direction: SortByDirection.asc,
     }
+    const initialSort = props.initialSort || defaultSort
 
     // State that is only stored in the component state
     const [selected, setSelected] = useState<{ [uid: string]: boolean }>({})
     const [actionsOpen, setActionsOpen] = useState(false)
-    const [preFilterSort, setPreFilterSort] = useState<ISortBy | undefined>(defaultSort)
+    const [preFilterSort, setPreFilterSort] = useState<ISortBy | undefined>(initialSort)
     const [expanded, setExpanded] = useState<{ [uid: string]: boolean }>({})
     const [openGroups, setOpenGroups] = useState<{ [key: string]: boolean }>({})
 
@@ -268,7 +270,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     const search = props.search || stateSearch
     const setSearch = props.setSearch || stateSetSearch
     const searchPlaceholder = props.searchPlaceholder || 'Search'
-    const [stateSort, stateSetSort] = useState<ISortBy | undefined>(defaultSort)
+    const [stateSort, stateSetSort] = useState<ISortBy | undefined>(initialSort)
     const sort = props.sort || stateSort
     const setSort = props.setSort || stateSetSort
 


### PR DESCRIPTION
Currently, if the `sort` property is set on AcmTable, then clicking on the table headers will not update it automatically. The consuming component would need to also set the `setSort` property with an appropriate function.

In GRC's use of the AcmTable we want to set an initial sorting for the table, but we would rather not manage `sort` and `setSort` in all of our components (in general -- there might still be times where it is necessary).

This adds a property so that the sortBy state is still managed by AcmTable directly, but users can set an initial state easily.

See https://github.com/open-cluster-management/backlog/issues/12610