### PR TITLE
Updated searchbar help icon style to be consistent with other component

### DIFF
--- a/src/AcmSearchbar/AcmSearchbar.tsx
+++ b/src/AcmSearchbar/AcmSearchbar.tsx
@@ -143,7 +143,7 @@ export function AcmSearchbar(props: AcmSearchbarProps) {
                 className={'help-button'}
                 onClick={toggleInfoModal}
                 noVerticalAlign
-                title={'Open help modal'}
+                title={'Open Help Modal'}
             />
             <SearchIcon className={'search-icon'} noVerticalAlign />
         </div>


### PR DESCRIPTION
To remain consistent with the other components, this will just update the string style for the help icon when hovered over.

Issue: https://github.com/open-cluster-management/backlog/issues/12351