### PR TITLE
adding callback to support hive log function

### DIFF
--- a/src/AcmProgressTracker/AcmProgressTracker.stories.tsx
+++ b/src/AcmProgressTracker/AcmProgressTracker.stories.tsx
@@ -25,7 +25,7 @@ export const ProgressTracker = () => {
             statusSubtitle: 'No jobs selected',
             link: {
                 linkName: 'Learn more about automation',
-                linkUrl: '',
+                linkCallback: () => window.open(''),
             },
         },
         {

--- a/src/AcmProgressTracker/AcmProgressTracker.test.tsx
+++ b/src/AcmProgressTracker/AcmProgressTracker.test.tsx
@@ -29,6 +29,10 @@ describe('AcmProgressTracker', () => {
                 statusType: StatusType.progress,
                 statusText: 'Cluster install',
                 statusSubtitle: 'Installing',
+                link: {
+                    linkName: 'Learn more',
+                    linkCallback: () => window.open('/ansible/url/docs'),
+                },
             },
             {
                 statusType: StatusType.empty,
@@ -62,6 +66,8 @@ describe('AcmProgressTracker', () => {
         expect(getByText('Post-creation jobs')).toBeInTheDocument()
         userEvent.click(getByText('View logs'))
         expect(window.open).toHaveBeenCalledWith('/ansible/url')
+        userEvent.click(getByText('Learn more'))
+        expect(window.open).toHaveBeenCalledWith('/ansible/url/docs')
     })
     test('renders stacked status', async () => {
         const { getByText } = render(<ProgressTracker isStacked={true} />)

--- a/src/AcmProgressTracker/AcmProgressTracker.tsx
+++ b/src/AcmProgressTracker/AcmProgressTracker.tsx
@@ -27,9 +27,10 @@ export type ProgressTrackerStep = {
 }
 
 export type ProgressTrackerStepLink = {
-    linkUrl: string
+    linkUrl?: string
     linkName: string
     isDisabled?: boolean
+    linkCallback?: () => void
 }
 
 enum StatusType {
@@ -132,7 +133,9 @@ export function AcmProgressTracker(props: AcmProgressTrackerProps) {
                                     isDisabled={step.link.isDisabled}
                                     onClick={() => {
                                         /* istanbul ignore next */
-                                        window.open(step.link?.linkUrl)
+                                        step.link?.linkUrl && window.open(step.link?.linkUrl)
+                                        /* istanbul ignore next */
+                                        step.link?.linkCallback && step.link?.linkCallback()
                                     }}
                                 >
                                     {step.link.linkName}


### PR DESCRIPTION
Signed-off-by: randybrunopiverger <rbrunopi@redhat.com>

The current hive notification link uses an onClick to trigger a Get call for the hive pod. Rather than refactor this method, I want to use it with my status rollup. To do this, it will need to accept a callback as a prop.