### PR TITLE
add light variant if toolbar exists

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -568,6 +568,10 @@ describe('AcmTable', () => {
         const { queryByText } = render(<Table items={[]} emptyState={<div>Look elsewhere!</div>} />)
         expect(queryByText('Look elsewhere!')).toBeVisible()
     })
+    test('can provide default empty state with extra toolbar controls', () => {
+        const { queryByText } = render(<Table items={[]} useExtraToolbarControls={true} />)
+        expect(queryByText('No addresses found')).toBeVisible()
+    })
     test('can render as a controlled component', () => {
         const setPage = jest.fn()
         const setSearch = jest.fn()

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -831,19 +831,17 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                     </EmptyState>
                 </PageSection>
             ) : items.length === 0 ? (
-                props.emptyState ? (
-                    <PageSection padding={{ default: 'noPadding' }}>{props.emptyState}</PageSection>
-                ) : (
-                    <PageSection
-                        variant={props.extraToolbarControls ? 'light' : 'default'}
-                        padding={{ default: 'noPadding' }}
-                    >
+                <PageSection
+                    variant={props.extraToolbarControls ? 'light' : 'default'}
+                    padding={{ default: 'noPadding' }}
+                >
+                    {props.emptyState ?? (
                         <AcmEmptyState
                             title={`No ${props.plural} found`}
                             message={`You do not have any ${props.plural} yet.`}
                         />
-                    </PageSection>
-                )
+                    )}
+                </PageSection>
             ) : (
                 <Fragment>
                     <div ref={outerDivRef} className={classes.outerDiv}>

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -834,7 +834,10 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                 props.emptyState ? (
                     <PageSection padding={{ default: 'noPadding' }}>{props.emptyState}</PageSection>
                 ) : (
-                    <PageSection padding={{ default: 'noPadding' }}>
+                    <PageSection
+                        variant={props.extraToolbarControls ? 'light' : 'default'}
+                        padding={{ default: 'noPadding' }}
+                    >
                         <AcmEmptyState
                             title={`No ${props.plural} found`}
                             message={`You do not have any ${props.plural} yet.`}


### PR DESCRIPTION
Signed-off-by: Richie Piya <rpiyasirisilp@gmail.com>

https://github.com/open-cluster-management/backlog/issues/12961

Empty state when extra toolbar is present (for tables)
<img width="1298" alt="Screen Shot 2021-06-14 at 11 17 44 AM" src="https://user-images.githubusercontent.com/39634227/121921627-2d18d780-cd07-11eb-8929-3a73bf77a7ad.png">

Empty state when there is no extra toolbar
<img width="1296" alt="Screen Shot 2021-06-14 at 11 17 28 AM" src="https://user-images.githubusercontent.com/39634227/121921631-2e4a0480-cd07-11eb-83c2-78a525d4c410.png">
