### PR TITLE
AcmAutoRefreshSelect: Prevent refresh when disabled and unhidden

### DIFF
--- a/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.test.tsx
+++ b/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.test.tsx
@@ -42,7 +42,7 @@ describe('AcmAutoRefreshSelect ', () => {
         render(<AcmAutoRefreshSelect refetch={refetch} />)
 
         expect(window.localStorage.getItem).toHaveBeenCalledTimes(1)
-        expect(window.localStorage.setItem).toHaveBeenCalledTimes(2)
+        expect(window.localStorage.setItem).toHaveBeenCalledTimes(1)
         expect(window.localStorage.setItem).toHaveBeenCalledWith('acm-page-refresh-interval', '60000')
     })
 
@@ -116,30 +116,80 @@ describe('AcmAutoRefreshSelect ', () => {
     })
 
     test('refetch is not fired when the browser is hidden', async () => {
-        const refetchFn = jest.fn()
-        let hidden = false
+        let eventCallback: unknown = null
 
-        Object.defineProperty(document, 'hidden', {
-            get: () => hidden,
-        })
-        Object.defineProperty(document, 'addEventListener', {
-            value: (eventName: string, eventCallback: () => void) => {
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(false)
+        jest.spyOn(document, 'addEventListener').mockImplementation(
+            (eventName: string, callback: EventListenerOrEventListenerObject) => {
                 if (eventName == 'visibilitychange') {
-                    act(() => {
-                        setTimeout(() => {
-                            hidden = true
-                            eventCallback()
-                        }, 10)
-                    })
+                    eventCallback = callback
                 }
-            },
-        })
+            }
+        )
 
+        render(<AcmAutoRefreshSelect refetch={refetch} refreshIntervals={[1, 30, 60]} pollInterval={100} />)
+        expect(refetch).toHaveBeenCalledTimes(1) // initial fetch only
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(true)
         await act(async () => {
-            render(<AcmAutoRefreshSelect refetch={refetch} refreshIntervals={[1, 30, 60]} pollInterval={100} />)
-            await new Promise((resolve) => setTimeout(resolve, 200))
+            expect(eventCallback).not.toBeNull()
+            if (typeof eventCallback === 'function') {
+                eventCallback()
+            }
         })
-        expect(refetchFn).toHaveBeenCalledTimes(0)
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        expect(refetch).toHaveBeenCalledTimes(1) // still initial fetch only
+    })
+
+    test('refetch is fired when the browser is unhidden', async () => {
+        let eventCallback: unknown = null
+
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(true)
+        jest.spyOn(document, 'addEventListener').mockImplementation(
+            (eventName: string, callback: EventListenerOrEventListenerObject) => {
+                if (eventName == 'visibilitychange') {
+                    eventCallback = callback
+                }
+            }
+        )
+
+        render(<AcmAutoRefreshSelect refetch={refetch} refreshIntervals={[1, 30, 60]} pollInterval={100} />)
+        expect(refetch).toHaveBeenCalledTimes(1) // initial fetch only
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        expect(refetch).toHaveBeenCalledTimes(1) // still initial fetch only
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(false)
+        await act(async () => {
+            expect(eventCallback).not.toBeNull()
+            if (typeof eventCallback === 'function') {
+                eventCallback()
+            }
+        })
+        await new Promise((resolve) => setTimeout(resolve, 100))
+        expect(refetch).toHaveBeenCalledTimes(3) // unhide + interval refetch
+    })
+
+    test('refetch is not fired when disabled and the browser is unhidden', async () => {
+        let eventCallback: unknown = null
+
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(true)
+        jest.spyOn(document, 'addEventListener').mockImplementation(
+            (eventName: string, callback: EventListenerOrEventListenerObject) => {
+                if (eventName == 'visibilitychange') {
+                    eventCallback = callback
+                }
+            }
+        )
+
+        render(<AcmAutoRefreshSelect refetch={refetch} refreshIntervals={[1, 30, 60]} pollInterval={0} />)
+        expect(refetch).toHaveBeenCalledTimes(1) // initial fetch only
+        jest.spyOn(document, 'hidden', 'get').mockReturnValue(false)
+        await act(async () => {
+            expect(eventCallback).not.toBeNull()
+            if (typeof eventCallback === 'function') {
+                eventCallback()
+            }
+        })
+        await new Promise((resolve) => setTimeout(resolve, 200))
+        expect(refetch).toHaveBeenCalledTimes(1) // still initial fetch only
     })
 
     test('refresh button fires refetch', () => {

--- a/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
+++ b/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
@@ -95,18 +95,20 @@ export function AcmAutoRefreshSelect(props: AcmAutoRefreshSelectProps) {
     const { refetch } = props
 
     useEffect(() => {
+        refetch()
+        setInitialFetchCalled(true)
         document.addEventListener('visibilitychange', onVisibilityChange)
         return () => document.removeEventListener('visibilitychange', onVisibilityChange)
     }, [])
 
     useEffect(() => {
-        if (!initialFetchCalled || (!docHidden && selected !== 0)) {
-            refetch()
-            setInitialFetchCalled(true)
-            if (!docHidden && selected !== 0) {
-                const interval = setInterval(() => refetch(), selected)
-                return () => clearInterval(interval)
+        if (!docHidden && selected !== 0) {
+            if (initialFetchCalled) {
+                // avoid double fetch on the first render
+                refetch()
             }
+            const interval = setInterval(() => refetch(), selected)
+            return () => clearInterval(interval)
         }
         return
     }, [selected, docHidden])

--- a/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
+++ b/src/AcmAutoRefreshSelect/AcmAutoRefreshSelect.tsx
@@ -101,17 +101,20 @@ export function AcmAutoRefreshSelect(props: AcmAutoRefreshSelectProps) {
         return () => document.removeEventListener('visibilitychange', onVisibilityChange)
     }, [])
 
-    useEffect(() => {
-        if (!docHidden && selected !== 0) {
-            if (initialFetchCalled) {
-                // avoid double fetch on the first render
-                refetch()
+    useEffect(
+        () => {
+            if (!docHidden && selected !== 0) {
+                if (initialFetchCalled) {
+                    // avoid double fetch on the first render
+                    refetch()
+                }
+                const interval = setInterval(() => refetch(), selected)
+                return () => clearInterval(interval)
             }
-            const interval = setInterval(() => refetch(), selected)
-            return () => clearInterval(interval)
-        }
-        return
-    }, [selected, docHidden])
+            return
+        },
+        [selected, docHidden] // intentionally exclude initialFetchCalled to avoid double refetch
+    )
 
     const handleKeyPress = (e: React.KeyboardEvent) => {
         /* istanbul ignore else */


### PR DESCRIPTION
When refresh is disabled, this change ensures that `refetch()` is called initially, but then is not called again when the page is hidden and unhidden.