### PR TITLE
don't show switcher if kube version is too low

### DIFF
--- a/src/AcmHeader/AcmHeader.tsx
+++ b/src/AcmHeader/AcmHeader.tsx
@@ -772,7 +772,7 @@ export function AcmHeader(props: AcmHeaderProps) {
                     nav={
                         <NavExpandableList
                             route={props.route}
-                            showSwitcher={true}
+                            showSwitcher={appSwitcherExists}
                             postClick={() => {
                                 if (!isFullWidthPage) setNavOpen(false)
                             }}


### PR DESCRIPTION
accidentally changed this in a previous PR, this is to revert it