### PR TITLE
Refactor AcmTable dropdown to use AcmDropdown

### DIFF
--- a/src/AcmDropdown/AcmDropdown.tsx
+++ b/src/AcmDropdown/AcmDropdown.tsx
@@ -8,6 +8,7 @@ import {
     DropdownPosition,
     KebabToggle,
     DropdownProps,
+    TooltipPosition,
 } from '@patternfly/react-core'
 import { makeStyles } from '@material-ui/styles'
 import { TooltipWrapper } from '../utils'
@@ -29,6 +30,7 @@ export type AcmDropdownProps = Props & {
     isPlain?: boolean
     isPrimary?: boolean
     onToggle?: (isOpen?: boolean) => void
+    tooltipPosition?: TooltipPosition
 }
 
 export type AcmDropdownItems = {
@@ -39,6 +41,7 @@ export type AcmDropdownItems = {
     text: string | React.ReactNode
     href?: string
     icon?: React.ReactNode
+    tooltipPosition?: TooltipPosition
 }
 
 const useStyles = makeStyles({
@@ -106,7 +109,11 @@ export function AcmDropdown(props: AcmDropdownProps) {
     }
 
     return (
-        <TooltipWrapper showTooltip={props.isDisabled && !!props.tooltip} tooltip={props.tooltip}>
+        <TooltipWrapper
+            showTooltip={props.isDisabled && !!props.tooltip}
+            tooltip={props.tooltip}
+            tooltipPosition={props.tooltipPosition}
+        >
             <Dropdown
                 className={classes.button}
                 onMouseOver={props.onHover}
@@ -116,6 +123,7 @@ export function AcmDropdown(props: AcmDropdownProps) {
                         showTooltip={item.isDisabled && !!item.tooltip}
                         tooltip={item.tooltip}
                         key={item.id}
+                        tooltipPosition={item.tooltipPosition}
                     >
                         <DropdownItem {...item} onClick={() => onSelect(item.id)}>
                             {item.text}

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -18,6 +18,7 @@ import { AcmPage, AcmPageContent, AcmPageHeader } from '../AcmPage/AcmPage'
 import { Provider } from '../AcmProvider'
 import { AcmInlineProvider } from '../AcmProvider/AcmInlineProvider/AcmInlineProvider'
 import { AcmTable, IAcmTableColumn } from '../AcmTable/AcmTable'
+import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 
 interface IExampleData {
     uid: number
@@ -44,7 +45,7 @@ export default {
         'Include rowActionResolver': { control: { type: 'boolean' }, defaultValue: false },
         'Include bulkActions': { control: { type: 'boolean' }, defaultValue: true },
         'Include extraToolbarControls': { control: { type: 'boolean' }, defaultValue: true },
-        'Include tableDropdown': { control: { type: 'boolean' }, defaultValue: true },
+        'Include customTableAction': { control: { type: 'boolean' }, defaultValue: true },
         'Use groupSummaryFn': { control: { type: 'boolean' }, defaultValue: false },
         gridBreakPoint: {
             options: ['dynamic', ...Object.values(TableGridBreakpoint)],
@@ -63,7 +64,7 @@ export default {
         groupFn: hidden,
         groupSummaryFn: hidden,
         tableActions: hidden,
-        tableDropdown: hidden,
+        customTableAction: hidden,
         rowActions: hidden,
         rowActionResolver: hidden,
         bulkActions: hidden,
@@ -370,33 +371,38 @@ function commonProperties(
                 <ToggleGroupItem text="View 2" />
             </ToggleGroup>
         ) : undefined,
-        tableDropdown: args['Include tableDropdown']
-            ? {
-                  id: 'create',
-                  isDisabled: false,
-                  toggleText: 'Create',
-                  disableText: 'Disabled',
-                  actions: [
-                      {
-                          id: 'action1',
-                          isDisabled: false,
-                          text: 'Action 1',
-                          tooltip: 'Disabled',
-                          href: '/action1',
-                          tooltipPosition: TooltipPosition.right,
-                      },
-                      {
-                          id: 'action2',
-                          isDisabled: false,
-                          text: 'Action 2',
-                          tooltip: 'Disabled',
-                          href: '/action1',
-                          tooltipPosition: TooltipPosition.right,
-                      },
-                  ],
-                  handleSelect: () => null,
-                  tooltipPosition: TooltipPosition.right,
-              }
+        customTableAction: args['Include customTableAction']
+            ? (
+                <AcmDropdown
+                    isDisabled={false}
+                    tooltip="Disabled"
+                    id="create"
+                    onSelect={() => null}
+                    text="Create"
+                    dropdownItems={[
+                        {
+                            id: 'action1',
+                            isDisabled: false,
+                            text: 'Action 1',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                        {
+                            id: 'action2',
+                            isDisabled: false,
+                            text: 'Action 2',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                    ]}
+                    isKebab={false}
+                    isPlain={true}
+                    isPrimary={true}
+                    tooltipPosition={TooltipPosition.right}
+                />
+            )
             : undefined,
     }
 }

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -9,6 +9,7 @@ import {
     TextVariants,
     ToggleGroup,
     ToggleGroupItem,
+    TooltipPosition,
 } from '@patternfly/react-core'
 import { fitContent, TableGridBreakpoint, truncate } from '@patternfly/react-table'
 import React, { useState } from 'react'
@@ -379,18 +380,22 @@ function commonProperties(
                       {
                           id: 'action1',
                           isDisabled: false,
-                          component: 'div',
-                          children: 'Action 1',
-                          disableText: 'Disabled',
+                          text: 'Action 1',
+                          tooltip: 'Disabled',
+                          href: '/action1',
+                          tooltipPosition: TooltipPosition.right,
                       },
                       {
                           id: 'action2',
                           isDisabled: false,
-                          component: 'div',
-                          children: 'Action 2',
-                          disableText: 'Disabled',
+                          text: 'Action 2',
+                          tooltip: 'Disabled',
+                          href: '/action1',
+                          tooltipPosition: TooltipPosition.right,
                       },
                   ],
+                  handleSelect: () => null,
+                  tooltipPosition: TooltipPosition.right,
               }
             : undefined,
     }

--- a/src/AcmTable/AcmTable.stories.tsx
+++ b/src/AcmTable/AcmTable.stories.tsx
@@ -371,39 +371,37 @@ function commonProperties(
                 <ToggleGroupItem text="View 2" />
             </ToggleGroup>
         ) : undefined,
-        customTableAction: args['Include customTableAction']
-            ? (
-                <AcmDropdown
-                    isDisabled={false}
-                    tooltip="Disabled"
-                    id="create"
-                    onSelect={() => null}
-                    text="Create"
-                    dropdownItems={[
-                        {
-                            id: 'action1',
-                            isDisabled: false,
-                            text: 'Action 1',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                        {
-                            id: 'action2',
-                            isDisabled: false,
-                            text: 'Action 2',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                    ]}
-                    isKebab={false}
-                    isPlain={true}
-                    isPrimary={true}
-                    tooltipPosition={TooltipPosition.right}
-                />
-            )
-            : undefined,
+        customTableAction: args['Include customTableAction'] ? (
+            <AcmDropdown
+                isDisabled={false}
+                tooltip="Disabled"
+                id="create"
+                onSelect={() => null}
+                text="Create"
+                dropdownItems={[
+                    {
+                        id: 'action1',
+                        isDisabled: false,
+                        text: 'Action 1',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                    {
+                        id: 'action2',
+                        isDisabled: false,
+                        text: 'Action 2',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                ]}
+                isKebab={false}
+                isPlain={true}
+                isPrimary={true}
+                tooltipPosition={TooltipPosition.right}
+            />
+        ) : undefined,
     }
 }
 

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { ToggleGroup, ToggleGroupItem } from '@patternfly/react-core'
+import { ToggleGroup, ToggleGroupItem, TooltipPosition } from '@patternfly/react-core'
 import { fitContent, IRow, SortByDirection, TableGridBreakpoint } from '@patternfly/react-table'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -187,18 +187,22 @@ describe('AcmTable', () => {
                                   {
                                       id: 'action1',
                                       isDisabled: false,
-                                      component: 'div',
-                                      children: 'Action 1',
-                                      disableText: 'Disabled',
+                                      text: 'Action 1',
+                                      tooltip: 'Disabled',
+                                      href: '/action1',
+                                      tooltipPosition: TooltipPosition.right,
                                   },
                                   {
                                       id: 'action2',
                                       isDisabled: false,
-                                      component: 'div',
-                                      children: 'Action 2',
-                                      disableText: 'Disabled',
+                                      text: 'Action 2',
+                                      tooltip: 'Disabled',
+                                      href: '/action1',
+                                      tooltipPosition: TooltipPosition.right,
                                   },
                               ],
+                              handleSelect: () => null,
+                              tooltipPosition: TooltipPosition.right,
                           }
                         : undefined
                 }
@@ -808,6 +812,8 @@ describe('AcmTable', () => {
             toggleText: 'Create',
             disableText: 'Disabled',
             actions: [],
+            handleSelect: () => null,
+            tooltipPosition: TooltipPosition.right,
         }
         const { container } = render(
             <Table tableDropdown={tableDropdownData} useTableActions={false} useRowActions={false} />
@@ -825,18 +831,22 @@ describe('AcmTable', () => {
                 {
                     id: 'action1',
                     isDisabled: true,
-                    component: 'div',
-                    children: 'Action 1',
-                    disableText: 'Disabled',
+                    text: 'Action 1',
+                    tooltip: 'Disabled',
+                    href: '/action1',
+                    tooltipPosition: TooltipPosition.right,
                 },
                 {
                     id: 'action2',
                     isDisabled: false,
-                    component: 'div',
-                    children: 'Action 2',
-                    disableText: 'Disabled',
+                    text: 'Action 2',
+                    tooltip: 'Disabled',
+                    href: '/action1',
+                    tooltipPosition: TooltipPosition.right,
                 },
             ],
+            handleSelect: () => null,
+            tooltipPosition: TooltipPosition.right,
         }
         const { container, getByTestId } = render(
             <Table tableDropdown={tableDropdownData} useTableActions={false} useRowActions={false} />

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event'
 import { configureAxe } from 'jest-axe'
 import React, { useState } from 'react'
 import { AcmTable, AcmTablePaginationContextProvider, AcmTableProps } from './AcmTable'
+import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 import { exampleData } from './AcmTable.stories'
 const axe = configureAxe({
     rules: {
@@ -39,7 +40,7 @@ describe('AcmTable', () => {
             useRowActions?: boolean
             useBulkActions?: boolean
             useExtraToolbarControls?: boolean
-            useTableDropdown?: boolean
+            useCustomTableAction?: boolean
             searchPlaceholder?: string
             useSearch?: boolean
             transforms?: boolean
@@ -54,7 +55,7 @@ describe('AcmTable', () => {
             useBulkActions = false,
             useExtraToolbarControls = false,
             useSearch = true,
-            useTableDropdown = false,
+            useCustomTableAction = false,
         } = props
         const [items, setItems] = useState<IExampleData[]>(testItems)
         return (
@@ -176,34 +177,39 @@ describe('AcmTable', () => {
                         </ToggleGroup>
                     ) : undefined
                 }
-                tableDropdown={
-                    useTableDropdown
-                        ? {
-                              id: 'create',
-                              isDisabled: false,
-                              toggleText: 'Create',
-                              disableText: 'Disabled',
-                              actions: [
-                                  {
-                                      id: 'action1',
-                                      isDisabled: false,
-                                      text: 'Action 1',
-                                      tooltip: 'Disabled',
-                                      href: '/action1',
-                                      tooltipPosition: TooltipPosition.right,
-                                  },
-                                  {
-                                      id: 'action2',
-                                      isDisabled: false,
-                                      text: 'Action 2',
-                                      tooltip: 'Disabled',
-                                      href: '/action1',
-                                      tooltipPosition: TooltipPosition.right,
-                                  },
-                              ],
-                              handleSelect: () => null,
-                              tooltipPosition: TooltipPosition.right,
-                          }
+                customTableAction={
+                    useCustomTableAction
+                        ? (
+                            <AcmDropdown
+                                isDisabled={false}
+                                tooltip="Disabled"
+                                id="create"
+                                onSelect={() => null}
+                                text="Create"
+                                dropdownItems={[
+                                    {
+                                        id: 'action1',
+                                        isDisabled: false,
+                                        text: 'Action 1',
+                                        tooltip: 'Disabled',
+                                        href: '/action1',
+                                        tooltipPosition: TooltipPosition.right,
+                                    },
+                                    {
+                                        id: 'action2',
+                                        isDisabled: false,
+                                        text: 'Action 2',
+                                        tooltip: 'Disabled',
+                                        href: '/action1',
+                                        tooltipPosition: TooltipPosition.right,
+                                    },
+                                ]}
+                                isKebab={false}
+                                isPlain={true}
+                                isPrimary={true}
+                                tooltipPosition={TooltipPosition.right}
+                            />
+                        )
                         : undefined
                 }
                 {...props}
@@ -797,59 +803,86 @@ describe('AcmTable', () => {
         )
         userEvent.click(getByTestId('expandable-toggle0'))
     })
-    test('renders with tableDropdown', () => {
+    test('renders with customTableAction', () => {
         const { container, getByTestId } = render(
-            <Table useTableDropdown={true} useTableActions={false} useRowActions={false} />
+            <Table useCustomTableAction={true} useTableActions={false} useRowActions={false} />
         )
         expect(container.querySelector('table')).toBeInTheDocument()
         expect(container.querySelector('div .pf-c-dropdown__toggle')).toBeInTheDocument()
         userEvent.click(getByTestId('create'))
     })
-    test('renders with tableDropdown disabled', () => {
-        const tableDropdownData = {
-            id: 'create',
-            isDisabled: true,
-            toggleText: 'Create',
-            disableText: 'Disabled',
-            actions: [],
-            handleSelect: () => null,
-            tooltipPosition: TooltipPosition.right,
-        }
+    test('renders with customTableAction disabled', () => {
+        const customTableActionComponent = (
+            <AcmDropdown
+                    isDisabled={true}
+                    tooltip="Disabled"
+                    id="create"
+                    onSelect={() => null}
+                    text="Create"
+                    dropdownItems={[
+                        {
+                            id: 'action1',
+                            isDisabled: false,
+                            text: 'Action 1',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                        {
+                            id: 'action2',
+                            isDisabled: false,
+                            text: 'Action 2',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                    ]}
+                    isKebab={false}
+                    isPlain={true}
+                    isPrimary={true}
+                    tooltipPosition={TooltipPosition.right}
+                />
+        )
         const { container } = render(
-            <Table tableDropdown={tableDropdownData} useTableActions={false} useRowActions={false} />
+            <Table customTableAction={customTableActionComponent} useTableActions={false} useRowActions={false} />
         )
         expect(container.querySelector('table')).toBeInTheDocument()
         expect(container.querySelector('div .pf-c-dropdown__toggle')).toBeInTheDocument()
     })
     test('renders with tableDropdown some actions disabled', () => {
-        const tableDropdownData = {
-            id: 'create',
-            isDisabled: false,
-            toggleText: 'Create',
-            disableText: 'Disabled',
-            actions: [
-                {
-                    id: 'action1',
-                    isDisabled: true,
-                    text: 'Action 1',
-                    tooltip: 'Disabled',
-                    href: '/action1',
-                    tooltipPosition: TooltipPosition.right,
-                },
-                {
-                    id: 'action2',
-                    isDisabled: false,
-                    text: 'Action 2',
-                    tooltip: 'Disabled',
-                    href: '/action1',
-                    tooltipPosition: TooltipPosition.right,
-                },
-            ],
-            handleSelect: () => null,
-            tooltipPosition: TooltipPosition.right,
-        }
+        const customTableActionComponent = (
+            <AcmDropdown
+                    isDisabled={false}
+                    tooltip="Disabled"
+                    id="create"
+                    onSelect={() => null}
+                    text="Create"
+                    dropdownItems={[
+                        {
+                            id: 'action1',
+                            isDisabled: true,
+                            text: 'Action 1',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                        {
+                            id: 'action2',
+                            isDisabled: false,
+                            text: 'Action 2',
+                            tooltip: 'Disabled',
+                            href: '/action1',
+                            tooltipPosition: TooltipPosition.right,
+                        },
+                    ]}
+                    isKebab={false}
+                    isPlain={true}
+                    isPrimary={true}
+                    tooltipPosition={TooltipPosition.right}
+                />
+        )
         const { container, getByTestId } = render(
-            <Table tableDropdown={tableDropdownData} useTableActions={false} useRowActions={false} />
+            <Table customTableAction={customTableActionComponent} useTableActions={false} useRowActions={false} />
         )
         expect(container.querySelector('table')).toBeInTheDocument()
         expect(container.querySelector('div .pf-c-dropdown__toggle')).toBeInTheDocument()

--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -178,39 +178,37 @@ describe('AcmTable', () => {
                     ) : undefined
                 }
                 customTableAction={
-                    useCustomTableAction
-                        ? (
-                            <AcmDropdown
-                                isDisabled={false}
-                                tooltip="Disabled"
-                                id="create"
-                                onSelect={() => null}
-                                text="Create"
-                                dropdownItems={[
-                                    {
-                                        id: 'action1',
-                                        isDisabled: false,
-                                        text: 'Action 1',
-                                        tooltip: 'Disabled',
-                                        href: '/action1',
-                                        tooltipPosition: TooltipPosition.right,
-                                    },
-                                    {
-                                        id: 'action2',
-                                        isDisabled: false,
-                                        text: 'Action 2',
-                                        tooltip: 'Disabled',
-                                        href: '/action1',
-                                        tooltipPosition: TooltipPosition.right,
-                                    },
-                                ]}
-                                isKebab={false}
-                                isPlain={true}
-                                isPrimary={true}
-                                tooltipPosition={TooltipPosition.right}
-                            />
-                        )
-                        : undefined
+                    useCustomTableAction ? (
+                        <AcmDropdown
+                            isDisabled={false}
+                            tooltip="Disabled"
+                            id="create"
+                            onSelect={() => null}
+                            text="Create"
+                            dropdownItems={[
+                                {
+                                    id: 'action1',
+                                    isDisabled: false,
+                                    text: 'Action 1',
+                                    tooltip: 'Disabled',
+                                    href: '/action1',
+                                    tooltipPosition: TooltipPosition.right,
+                                },
+                                {
+                                    id: 'action2',
+                                    isDisabled: false,
+                                    text: 'Action 2',
+                                    tooltip: 'Disabled',
+                                    href: '/action1',
+                                    tooltipPosition: TooltipPosition.right,
+                                },
+                            ]}
+                            isKebab={false}
+                            isPlain={true}
+                            isPrimary={true}
+                            tooltipPosition={TooltipPosition.right}
+                        />
+                    ) : undefined
                 }
                 {...props}
             />
@@ -814,34 +812,34 @@ describe('AcmTable', () => {
     test('renders with customTableAction disabled', () => {
         const customTableActionComponent = (
             <AcmDropdown
-                    isDisabled={true}
-                    tooltip="Disabled"
-                    id="create"
-                    onSelect={() => null}
-                    text="Create"
-                    dropdownItems={[
-                        {
-                            id: 'action1',
-                            isDisabled: false,
-                            text: 'Action 1',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                        {
-                            id: 'action2',
-                            isDisabled: false,
-                            text: 'Action 2',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                    ]}
-                    isKebab={false}
-                    isPlain={true}
-                    isPrimary={true}
-                    tooltipPosition={TooltipPosition.right}
-                />
+                isDisabled={true}
+                tooltip="Disabled"
+                id="create"
+                onSelect={() => null}
+                text="Create"
+                dropdownItems={[
+                    {
+                        id: 'action1',
+                        isDisabled: false,
+                        text: 'Action 1',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                    {
+                        id: 'action2',
+                        isDisabled: false,
+                        text: 'Action 2',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                ]}
+                isKebab={false}
+                isPlain={true}
+                isPrimary={true}
+                tooltipPosition={TooltipPosition.right}
+            />
         )
         const { container } = render(
             <Table customTableAction={customTableActionComponent} useTableActions={false} useRowActions={false} />
@@ -852,34 +850,34 @@ describe('AcmTable', () => {
     test('renders with tableDropdown some actions disabled', () => {
         const customTableActionComponent = (
             <AcmDropdown
-                    isDisabled={false}
-                    tooltip="Disabled"
-                    id="create"
-                    onSelect={() => null}
-                    text="Create"
-                    dropdownItems={[
-                        {
-                            id: 'action1',
-                            isDisabled: true,
-                            text: 'Action 1',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                        {
-                            id: 'action2',
-                            isDisabled: false,
-                            text: 'Action 2',
-                            tooltip: 'Disabled',
-                            href: '/action1',
-                            tooltipPosition: TooltipPosition.right,
-                        },
-                    ]}
-                    isKebab={false}
-                    isPlain={true}
-                    isPrimary={true}
-                    tooltipPosition={TooltipPosition.right}
-                />
+                isDisabled={false}
+                tooltip="Disabled"
+                id="create"
+                onSelect={() => null}
+                text="Create"
+                dropdownItems={[
+                    {
+                        id: 'action1',
+                        isDisabled: true,
+                        text: 'Action 1',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                    {
+                        id: 'action2',
+                        isDisabled: false,
+                        text: 'Action 2',
+                        tooltip: 'Disabled',
+                        href: '/action1',
+                        tooltipPosition: TooltipPosition.right,
+                    },
+                ]}
+                isKebab={false}
+                isPlain={true}
+                isPrimary={true}
+                tooltipPosition={TooltipPosition.right}
+            />
         )
         const { container, getByTestId } = render(
             <Table customTableAction={customTableActionComponent} useTableActions={false} useRowActions={false} />

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -21,7 +21,6 @@ import {
     ToolbarGroup,
     ToolbarItem,
     Tooltip,
-    TooltipPosition,
 } from '@patternfly/react-core'
 import CaretDownIcon from '@patternfly/react-icons/dist/js/icons/caret-down-icon'
 import {
@@ -61,7 +60,6 @@ import React, {
 } from 'react'
 import { AcmButton } from '../AcmButton/AcmButton'
 import { AcmEmptyState } from '../AcmEmptyState/AcmEmptyState'
-import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 
 type SortFn<T> = (a: T, b: T) => number
 type CellFn<T> = (item: T) => ReactNode
@@ -96,27 +94,6 @@ export interface IAcmTableAction {
     isDisabled?: boolean | undefined
     tooltip?: string | React.ReactNode
     variant?: ButtonVariant
-}
-
-/* istanbul ignore next */
-export interface IAcmTableDropdown {
-    id: string
-    isDisabled?: boolean | undefined
-    toggleText: string
-    disableText?: string | React.ReactNode
-    actions: IAcmTableDropdownAction[]
-    handleSelect: () => void
-    tooltipPosition?: TooltipPosition
-}
-
-/* istanbul ignore next */
-export interface IAcmTableDropdownAction {
-    id: string
-    isDisabled?: boolean | undefined
-    href: string
-    text: string | React.ReactNode
-    tooltip?: string | React.ReactNode
-    tooltipPosition?: TooltipPosition
 }
 
 /* istanbul ignore next */
@@ -236,7 +213,7 @@ export interface AcmTableProps<T> {
     groupFn?: (item: T) => string | null
     groupSummaryFn?: (items: T[]) => IRow
     tableActions?: IAcmTableAction[]
-    tableDropdown?: IAcmTableDropdown
+    customTableAction?: ReactNode
     rowActions?: IAcmRowAction<T>[]
     rowActionResolver?: (item: T) => IAcmRowAction<T>[]
     bulkActions?: IAcmTableBulkAction<T>[]
@@ -270,7 +247,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         rowActions = [],
         rowActionResolver,
         tableActions = [],
-        tableDropdown,
+        customTableAction,
     } = props
 
     const defaultSort = {
@@ -729,24 +706,11 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     // Parse static actions
     const actions = parseRowAction(rowActions)
 
-    const renderDropdown = (tableDropdown: IAcmTableDropdown) => {
-        return (
-            <AcmDropdown
-                isDisabled={tableDropdown.isDisabled}
-                tooltip={tableDropdown.disableText}
-                id={tableDropdown.id}
-                onSelect={tableDropdown.handleSelect}
-                text={tableDropdown.toggleText}
-                dropdownItems={tableDropdown.actions}
-                isKebab={false}
-                isPlain={true}
-                isPrimary={true}
-                tooltipPosition={tableDropdown.tooltipPosition}
-            />
-        )
+    const renderCustomTableAction = (customTableAction: ReactNode) => {
+        return customTableAction
     }
 
-    const dropdownResults = tableDropdown && renderDropdown(tableDropdown)
+    const renderCustomTableActionResults = customTableAction && renderCustomTableAction(customTableAction)
 
     // Wrap provided action resolver
     let actionResolver: IActionsResolver | undefined
@@ -814,7 +778,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                                 ))}
                             </ToolbarGroup>
                         )}
-                        {dropdownResults}
+                        {renderCustomTableActionResults}
                         {Object.keys(selected).length > 0 && bulkActions.length > 0 && (
                             <ToolbarGroup variant="button-group">
                                 <ToolbarItem>

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -7,9 +7,10 @@ export function TooltipWrapper(props: {
     children: React.ReactElement
     showTooltip?: boolean
     tooltip?: string | React.ReactNode
+    tooltipPosition?: TooltipPosition
 }) {
     return props.showTooltip ? (
-        <Tooltip content={props.tooltip} position={TooltipPosition.top}>
+        <Tooltip content={props.tooltip} position={props.tooltipPosition || TooltipPosition.top}>
             {props.children}
         </Tooltip>
     ) : (


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Switched AcmTable tableDropdown to customTableAction for more extensibility and reduce code duplication
- Added option to TooltipWrapper to set the TooltipPosition

<img width="1290" alt="image" src="https://user-images.githubusercontent.com/38960034/129594524-c0bbd807-dd57-49d1-9ecd-f727a9785026.png">
