### PR TITLE
Put back customTableAction just for 2.4

### DIFF
--- a/src/AcmTable/AcmTable.test.tsx
+++ b/src/AcmTable/AcmTable.test.tsx
@@ -1,6 +1,6 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { ToggleGroup, ToggleGroupItem, ButtonVariant } from '@patternfly/react-core'
+import { ToggleGroup, ToggleGroupItem, ButtonVariant, TooltipPosition } from '@patternfly/react-core'
 import { fitContent, IRow, SortByDirection, TableGridBreakpoint } from '@patternfly/react-table'
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
@@ -8,6 +8,7 @@ import { configureAxe } from 'jest-axe'
 import React, { useState } from 'react'
 import { AcmTable, AcmTablePaginationContextProvider, AcmTableProps } from './AcmTable'
 import { exampleData } from './AcmTable.stories'
+import { AcmDropdown } from '../AcmDropdown/AcmDropdown'
 const axe = configureAxe({
     rules: {
         'scope-attr-valid': { enabled: false },
@@ -46,6 +47,7 @@ describe('AcmTable', () => {
             groupFn?: (item: IExampleData) => string | null
             groupSummaryFn?: (items: IExampleData[]) => IRow
             gridBreakPoint?: TableGridBreakpoint
+            useCustomTableAction?: boolean
         } & Partial<AcmTableProps<IExampleData>>
     ) => {
         const {
@@ -53,6 +55,7 @@ describe('AcmTable', () => {
             useRowActions = true,
             useExtraToolbarControls = false,
             useSearch = true,
+            useCustomTableAction = false,
         } = props
         const [items, setItems] = useState<IExampleData[]>(testItems)
         return (
@@ -210,6 +213,39 @@ describe('AcmTable', () => {
                             <ToggleGroupItem isSelected={true} text="View 1" />
                             <ToggleGroupItem text="View 2" />
                         </ToggleGroup>
+                    ) : undefined
+                }
+                customTableAction={
+                    useCustomTableAction ? (
+                        <AcmDropdown
+                            isDisabled={false}
+                            tooltip="Disabled"
+                            id="create"
+                            onSelect={() => null}
+                            text="Create"
+                            dropdownItems={[
+                                {
+                                    id: 'action1',
+                                    isDisabled: false,
+                                    text: 'Action 1',
+                                    tooltip: 'Disabled',
+                                    href: '/action1',
+                                    tooltipPosition: TooltipPosition.right,
+                                },
+                                {
+                                    id: 'action2',
+                                    isDisabled: false,
+                                    text: 'Action 2',
+                                    tooltip: 'Disabled',
+                                    href: '/action1',
+                                    tooltipPosition: TooltipPosition.right,
+                                },
+                            ]}
+                            isKebab={false}
+                            isPlain={true}
+                            isPrimary={true}
+                            tooltipPosition={TooltipPosition.right}
+                        />
                     ) : undefined
                 }
                 {...props}
@@ -906,5 +942,14 @@ describe('AcmTable', () => {
         userEvent.click(getByTestId('male'))
         userEvent.click(getAllByText('Clear all filters')[1])
         expect(container.querySelectorAll('.pf-c-chip-group__list-item')).toHaveLength(0)
+    })
+
+    test('renders with customTableAction', () => {
+        const { container, getByTestId } = render(
+            <Table useCustomTableAction={true} useTableActions={false} useRowActions={false} />
+        )
+        expect(container.querySelector('table')).toBeInTheDocument()
+        expect(container.querySelector('div .pf-c-dropdown__toggle')).toBeInTheDocument()
+        userEvent.click(getByTestId('create'))
     })
 })

--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -294,6 +294,7 @@ export interface AcmTableProps<T> {
     keyFn: (item: T) => string
     groupFn?: (item: T) => string | null
     groupSummaryFn?: (items: T[]) => IRow
+    customTableAction?: ReactNode
     tableActionButtons?: IAcmTableButtonAction[]
     tableActions?: IAcmTableAction<T>[]
     rowActions?: IAcmRowAction<T>[]
@@ -328,6 +329,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
         tableActions = [],
         rowActions = [],
         rowActionResolver,
+        customTableAction,
         filters = [],
     } = props
 
@@ -786,6 +788,12 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     // Parse static actions
     const actions = parseRowAction(rowActions)
 
+    const renderCustomTableAction = (customTableAction: ReactNode) => {
+        return customTableAction
+    }
+
+    const renderCustomTableActionResults = customTableAction && renderCustomTableAction(customTableAction)
+
     // Wrap provided action resolver
     let actionResolver: IActionsResolver | undefined
     if (rowActionResolver) {
@@ -895,6 +903,7 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
                         {tableActions.length > 0 && (
                             <TableActions actions={tableActions} selections={selected} items={items} keyFn={keyFn} />
                         )}
+                        {renderCustomTableActionResults}
                         {(!props.autoHidePagination || filtered.length > perPage) && (
                             <ToolbarItem variant="pagination">
                                 <Pagination


### PR DESCRIPTION
Signed-off-by: Feng Xiang <fxiang@redhat.com>

- Put back customTableAction just for 2.4

Since customTableAction will be removed in 2.5, I'm not putting back the storybook changes.