### PR TITLE
acm labels support for long labels

### DIFF
--- a/src/AcmLabels/AcmLabels.css
+++ b/src/AcmLabels/AcmLabels.css
@@ -1,0 +1,39 @@
+.acm-labels {
+    display: flex;
+    flex-wrap: wrap;
+    column-gap: 5px;
+    row-gap: 4px;
+    font-size: var(--pf-global--FontSize--sm);
+    color: var(--pf-global--Color--100);
+}
+
+.acm-label {
+    padding-top: var(--pf-global--spacer--xs);
+    padding-right: var(--pf-global--spacer--sm);
+    padding-bottom: var(--pf-global--spacer--xs);
+    padding-left: var(--pf-global--spacer--sm);
+    border-width: var(--pf-global--BorderWidth--sm);
+    border-color: var(--pf-global--BorderColor--100);
+    border-radius: var(--pf-global--BorderRadius--lg);
+    background-color: var(--pf-global--palette--black-150);
+    border-style: solid;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow-x: clip;
+}
+
+.acm-label-button {
+    color: var(--pf-global--palette--blue-400);
+    padding-top: var(--pf-global--spacer--xs);
+    padding-right: var(--pf-global--spacer--sm);
+    padding-bottom: var(--pf-global--spacer--xs);
+    padding-left: var(--pf-global--spacer--sm);
+    border-width: var(--pf-global--BorderWidth--sm);
+    border-color: var(--pf-global--palette--black-200);
+    border-radius: var(--pf-global--BorderRadius--lg);
+    border-style: solid;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow-x: clip;
+    cursor: pointer;
+}

--- a/src/AcmLabels/AcmLabels.css
+++ b/src/AcmLabels/AcmLabels.css
@@ -41,3 +41,7 @@
 .acm-label-button:hover {
     border-color: var(--pf-global--palette--black-300);
 }
+
+.acm-label-button:focus {
+    border-color: var(--pf-global--palette--blue-400);
+}

--- a/src/AcmLabels/AcmLabels.css
+++ b/src/AcmLabels/AcmLabels.css
@@ -37,3 +37,7 @@
     overflow-x: clip;
     cursor: pointer;
 }
+
+.acm-label-button:hover {
+    border-color: var(--pf-global--palette--black-300);
+}

--- a/src/AcmLabels/AcmLabels.test.tsx
+++ b/src/AcmLabels/AcmLabels.test.tsx
@@ -35,9 +35,10 @@ describe('AcmLabels', () => {
             <AcmLabels labels={{ foo: 'bar', cluster: 'management', empty: '' }} collapse={['cluster', 'empty']} />
         )
         expect(getByText('foo=bar')).toBeInTheDocument()
-        expect(getByText('2 more')).toBeInTheDocument()
         getByText('2 more').click()
         expect(getByText('cluster=management')).toBeInstanceOf(HTMLSpanElement)
         expect(getByText('empty')).toBeInTheDocument()
+        getByText('Show less').click()
+        expect(getByText('2 more')).toBeInTheDocument()
     })
 })

--- a/src/AcmLabels/AcmLabels.tsx
+++ b/src/AcmLabels/AcmLabels.tsx
@@ -1,17 +1,14 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
-import { CSSProperties } from '@material-ui/styles'
-import { Label, LabelGroup } from '@patternfly/react-core'
-import React, { Fragment, useMemo } from 'react'
+import { Tooltip } from '@patternfly/react-core'
+import React, { Fragment, useMemo, useState } from 'react'
+import './AcmLabels.css'
 
 export function AcmLabels(props: {
     labels?: string[] | Record<string, string>
     collapse?: string[]
-    style?: CSSProperties
     collapsedText?: string
     expandedText?: string
-    color?: 'blue' | 'cyan' | 'green' | 'orange' | 'purple' | 'red' | 'grey'
-    variant?: 'outline' | 'filled'
 }) {
     const labelsRecord: Record<string, string> = useMemo(() => {
         if (props.labels === undefined) return {}
@@ -44,23 +41,35 @@ export function AcmLabels(props: {
 
     if (props.labels === undefined) return <Fragment></Fragment>
 
+    const [showMore, setShowMore] = useState(false)
+    /* istanbul ignore next */
+    const collapsedText = props.collapsedText ?? `${hidden.length} more`
+    /* istanbul ignore next */
+    const expandedText = props.expandedText ?? 'Show less'
+
     return (
-        <LabelGroup
-            style={props.style}
-            numLabels={labels.length}
-            collapsedText={props.collapsedText}
-            expandedText={props.expandedText}
-        >
+        <span className="acm-labels">
             {labels.map((label) => (
-                <Label key={label} title={label} variant={props.variant} color={props.color}>
-                    {label}
-                </Label>
+                <Tooltip key={label} content={label}>
+                    <span className="acm-label">{label}</span>
+                </Tooltip>
             ))}
-            {hidden.map((label) => (
-                <Label key={label} title={label} variant={props.variant} color={props.color}>
-                    {label}
-                </Label>
-            ))}
-        </LabelGroup>
+            {hidden.length > 0 &&
+                showMore &&
+                hidden.map((label) => (
+                    <Tooltip key={label} content={label}>
+                        <span className="acm-label">{label}</span>
+                    </Tooltip>
+                ))}
+            {hidden.length > 0 && showMore ? (
+                <span className="acm-label-button" onClick={() => setShowMore(!showMore)}>
+                    {expandedText}
+                </span>
+            ) : (
+                <span className="acm-label-button" onClick={() => setShowMore(!showMore)}>
+                    {collapsedText}
+                </span>
+            )}
+        </span>
     )
 }

--- a/src/AcmLabels/AcmLabels.tsx
+++ b/src/AcmLabels/AcmLabels.tsx
@@ -62,11 +62,11 @@ export function AcmLabels(props: {
                     </Tooltip>
                 ))}
             {hidden.length > 0 && showMore ? (
-                <span className="acm-label-button" onClick={() => setShowMore(!showMore)}>
+                <span className="acm-label-button" tabIndex={1} onClick={() => setShowMore(!showMore)}>
                     {expandedText}
                 </span>
             ) : (
-                <span className="acm-label-button" onClick={() => setShowMore(!showMore)}>
+                <span className="acm-label-button" tabIndex={1} onClick={() => setShowMore(!showMore)}>
                     {collapsedText}
                 </span>
             )}

--- a/src/AcmLabels/AcmLabels.tsx
+++ b/src/AcmLabels/AcmLabels.tsx
@@ -62,11 +62,31 @@ export function AcmLabels(props: {
                     </Tooltip>
                 ))}
             {hidden.length > 0 && showMore ? (
-                <span className="acm-label-button" tabIndex={1} onClick={() => setShowMore(!showMore)}>
+                <span
+                    className="acm-label-button"
+                    tabIndex={1}
+                    onClick={() => setShowMore(!showMore)}
+                    onKeyPress={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            setShowMore(!showMore)
+                            e.preventDefault()
+                        }
+                    }}
+                >
                     {expandedText}
                 </span>
             ) : (
-                <span className="acm-label-button" tabIndex={1} onClick={() => setShowMore(!showMore)}>
+                <span
+                    className="acm-label-button"
+                    tabIndex={1}
+                    onClick={() => setShowMore(!showMore)}
+                    onKeyPress={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                            setShowMore(!showMore)
+                            e.preventDefault()
+                        }
+                    }}
+                >
                     {collapsedText}
                 </span>
             )}

--- a/src/AcmLabels/AcmLabels.tsx
+++ b/src/AcmLabels/AcmLabels.tsx
@@ -1,7 +1,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 import { Tooltip } from '@patternfly/react-core'
-import React, { Fragment, useMemo, useState } from 'react'
+import React, { Fragment, useCallback, useMemo, useState } from 'react'
 import './AcmLabels.css'
 
 export function AcmLabels(props: {
@@ -42,10 +42,22 @@ export function AcmLabels(props: {
     if (props.labels === undefined) return <Fragment></Fragment>
 
     const [showMore, setShowMore] = useState(false)
+
     /* istanbul ignore next */
     const collapsedText = props.collapsedText ?? `${hidden.length} more`
+
     /* istanbul ignore next */
     const expandedText = props.expandedText ?? 'Show less'
+
+    const onClick = useCallback(() => setShowMore((showMore) => !showMore), [])
+
+    /* istanbul ignore next */
+    const onKeyPress = useCallback((e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            setShowMore(!showMore)
+            e.preventDefault()
+        }
+    }, [])
 
     return (
         <span className="acm-labels">
@@ -62,31 +74,11 @@ export function AcmLabels(props: {
                     </Tooltip>
                 ))}
             {hidden.length > 0 && showMore ? (
-                <span
-                    className="acm-label-button"
-                    tabIndex={1}
-                    onClick={() => setShowMore(!showMore)}
-                    onKeyPress={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            setShowMore(!showMore)
-                            e.preventDefault()
-                        }
-                    }}
-                >
+                <span className="acm-label-button" tabIndex={0} onClick={onClick} onKeyPress={onKeyPress}>
                     {expandedText}
                 </span>
             ) : (
-                <span
-                    className="acm-label-button"
-                    tabIndex={1}
-                    onClick={() => setShowMore(!showMore)}
-                    onKeyPress={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                            setShowMore(!showMore)
-                            e.preventDefault()
-                        }
-                    }}
-                >
+                <span className="acm-label-button" tabIndex={0} onClick={onClick} onKeyPress={onKeyPress}>
                     {collapsedText}
                 </span>
             )}


### PR DESCRIPTION
Signed-off-by: James Talton <jtalton@redhat.com>

Fix for
**Labels in cluster details overlap the second column**
https://github.com/open-cluster-management/backlog/issues/16152

Support for label text trimming and ellipsis plus tooltip.
Top is the old labels, bottom is the fixed example.

![Screen Shot 2021-09-17 at 1 43 28 PM](https://user-images.githubusercontent.com/6277895/133832552-121f076b-9973-4a24-809e-eaf9a9c86d27.png)


