### PR TITLE
Fix off-by-one error on page adjustments

### DIFF
--- a/src/AcmTable/AcmTable.tsx
+++ b/src/AcmTable/AcmTable.tsx
@@ -558,8 +558,8 @@ export function AcmTable<T>(props: AcmTableProps<T>) {
     const paged = useMemo<ITableItem<T>[]>(() => {
         let start = (page - 1) * perPage
         let actualPage = page
-        if (start > grouped.length) {
-            actualPage = Math.floor(grouped.length / perPage) + 1
+        if (start >= grouped.length) {
+            actualPage = Math.ceil(grouped.length / perPage)
             start = (actualPage - 1) * perPage
             setPage(actualPage)
         }


### PR DESCRIPTION
When deleting all items on the final page, the page now adjusted correctly to the new final page.

Signed-off-by: Kevin Cormier <kcormier@redhat.com>